### PR TITLE
fix: align docs with code — health_check() returns dict, AgentEvent→EventEnvelope

### DIFF
--- a/.cursor/rules/event-contracts.mdc
+++ b/.cursor/rules/event-contracts.mdc
@@ -11,7 +11,7 @@ globs:
 
 ## Core Rules
 
-1. **Events only.** Agents communicate exclusively via `AgentEvent` objects through the message bus. Never call another agent's methods directly.
+1. **Events only.** Agents communicate exclusively via `EventEnvelope` objects through the message bus. Never call another agent's methods directly.
 2. **Orchestrator is sole failure consumer.** Only the Orchestration Agent subscribes to `*Failed` and `*Alert` events.
 3. **Propagate `correlation_id`.** Every event in a pipeline run shares the same `correlation_id`, set by the initial `IngestBatch` and passed unchanged through all downstream events.
 4. **Version payloads.** Use `schema_version` field. Increment on breaking payload changes.
@@ -57,7 +57,7 @@ Each event's `payload` dict should include:
 
 ## Adding a New Event Type
 
-1. Define it in `agents/common/events/` following the `AgentEvent` dataclass
+1. Define it in `agents/common/events/` following the `EventEnvelope` dataclass
 2. Add it to the event catalog (this doc and `ARCHITECTURE_DEEP.md`)
 3. Register the Orchestrator as a consumer
 4. If it's a failure event, only Orchestrator may consume it

--- a/.cursor/rules/project-context.mdc
+++ b/.cursor/rules/project-context.mdc
@@ -23,11 +23,11 @@ Read these before implementing anything — they are the source of truth:
 ## Non-Negotiable Rules
 
 1. **One agent = one responsibility.** Helper logic (dedup, validation, field mapping, confidence scoring) stays inside the owning agent. Never promoted to its own agent.
-2. **Events-only communication.** Agents communicate via typed, versioned `AgentEvent` objects through the message bus. Direct function calls between agents are forbidden.
+2. **Events-only communication.** Agents communicate via typed, versioned `EventEnvelope` objects through the message bus. Direct function calls between agents are forbidden.
 3. **Orchestration Agent is the sole consumer** of `*Failed` and `*Alert` events. No other agent reacts to another agent's failures.
 4. **No cross-agent state writes.** An agent never writes to another agent's internal state.
 5. **Every agent class exposes `health_check()`** returning `{"status": "ok"|"degraded"|"down", "agent": str, "last_run": str, "metrics": dict}`.
-6. **Python agents use SQLAlchemy + pyodbc for MSSQL.** Never import or invoke Prisma from Python.
+6. **Python agents use SQLAlchemy + psycopg2 for PostgreSQL.** Never import or invoke Prisma from Python.
 7. **No credentials in code or logs.** All secrets via `os.getenv()`. Use structlog with no PII.
 8. **Do NOT implement Phase 2 items** unless the user explicitly instructs you to. Phase 2 includes: demand_analysis implementation, circuit_breaker, saga, admin_api, full enrichment resolvers, external message bus.
 
@@ -50,7 +50,7 @@ Unless explicitly instructed, never modify files outside `agents/`:
 | LLM adapter | LangChain + Azure OpenAI (provider-agnostic via `LLM_PROVIDER` env var) |
 | Tracing | LangSmith |
 | Scheduling | APScheduler |
-| DB access | SQLAlchemy + pyodbc → MSSQL |
+| DB access | SQLAlchemy + psycopg2 → PostgreSQL |
 | Scraping | Crawl4AI |
 | API ingestion | httpx |
 | Dashboards | Streamlit |

--- a/.cursor/rules/python-agent-patterns.mdc
+++ b/.cursor/rules/python-agent-patterns.mdc
@@ -14,19 +14,19 @@ All Python code in `agents/` must follow these patterns exactly.
 Every inter-agent communication uses this shape. Never invent a different structure.
 
 ```python
-# agents/common/events/base.py
-from dataclasses import dataclass, field
+# agents/common/event_envelope.py
+from pydantic import BaseModel, Field
 from datetime import datetime
-from uuid import uuid4
+from typing import Any
+import uuid
 
-@dataclass
-class AgentEvent:
-    event_id: str = field(default_factory=lambda: str(uuid4()))
-    correlation_id: str = ""       # propagated UNCHANGED from IngestBatch through all downstream events
-    agent_id: str = ""             # e.g. "ingestion_agent"
-    timestamp: datetime = field(default_factory=datetime.utcnow)
+class EventEnvelope(BaseModel):
+    event_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    correlation_id: str            # propagated UNCHANGED from IngestBatch through all downstream events
+    agent_id: str                  # e.g. "ingestion-agent"
+    timestamp: datetime = Field(default_factory=datetime.utcnow)
     schema_version: str = "1.0"    # increment on breaking payload changes
-    payload: dict = field(default_factory=dict)
+    payload: dict[str, Any]
 ```
 
 ## Agent Class Skeleton
@@ -36,7 +36,7 @@ Every agent follows this structure:
 ```python
 import os
 import structlog
-from agents.common.events.base import AgentEvent
+from agents.common.event_envelope import EventEnvelope
 from agents.common.llm_adapter import get_adapter
 
 log = structlog.get_logger()
@@ -49,7 +49,7 @@ class IngestionAgent:
         self.last_run_at = None
         self.last_run_metrics = {}
 
-    def process(self, event: AgentEvent | None = None) -> AgentEvent:
+    def process(self, event: EventEnvelope | None = None) -> EventEnvelope:
         """Main processing method. Consumes an input event, returns an output event."""
         ...
 
@@ -95,9 +95,9 @@ log.error("source_unreachable", source="jsearch", attempt=3, max_retries=5)
 
 ## Database Access — SQLAlchemy Only
 
-Python agents access MSSQL via SQLAlchemy. **Never import or use Prisma from Python.**
+Python agents access PostgreSQL via SQLAlchemy + psycopg2. **Never import or use Prisma from Python.**
 
-Use `PYTHON_DATABASE_URL` (not `DATABASE_URL` — that is Prisma's `sqlserver://` format and is incompatible with SQLAlchemy). `PYTHON_DATABASE_URL` uses `mssql+pyodbc://` format.
+Use `PYTHON_DATABASE_URL` (not `DATABASE_URL` — that is Prisma's format and is incompatible with SQLAlchemy). `PYTHON_DATABASE_URL` uses `postgresql+psycopg2://` format.
 
 ```python
 import os
@@ -107,7 +107,7 @@ from sqlalchemy.orm import Session
 engine = create_engine(os.getenv("PYTHON_DATABASE_URL"))
 
 with Session(engine) as session:
-    result = session.execute(text("SELECT TOP 100 * FROM job_postings WHERE company_id IS NOT NULL"))
+    result = session.execute(text("SELECT * FROM dbo.job_postings WHERE company_id IS NOT NULL LIMIT 100"))
     rows = result.fetchall()
 ```
 
@@ -116,7 +116,7 @@ with Session(engine) as session:
 All credentials from `os.getenv()`. Never hardcode. Key variables:
 
 ```python
-os.getenv("PYTHON_DATABASE_URL")             # SQLAlchemy pyodbc URL: mssql+pyodbc://user:pass@host:port/db?driver=...
+os.getenv("PYTHON_DATABASE_URL")             # SQLAlchemy psycopg2 URL: postgresql+psycopg2://user:pass@host:port/db
 os.getenv("AZURE_OPENAI_API_KEY")            # LLM credentials
 os.getenv("AZURE_OPENAI_ENDPOINT")
 os.getenv("AZURE_OPENAI_DEPLOYMENT_NAME")

--- a/.cursor/rules/testing-standards.mdc
+++ b/.cursor/rules/testing-standards.mdc
@@ -30,7 +30,7 @@ cd agents && pytest -x -v                            # stop on first failure, ve
 import pytest
 from unittest.mock import patch, MagicMock
 from agents.ingestion.agent import IngestionAgent
-from agents.common.events.base import AgentEvent
+from agents.common.event_envelope import EventEnvelope
 
 class TestIngestionAgent:
     def setup_method(self):
@@ -45,7 +45,7 @@ class TestIngestionAgent:
 
     def test_emits_ingest_batch_event(self):
         event = self.agent.process()
-        assert isinstance(event, AgentEvent)
+        assert isinstance(event, EventEnvelope)
         assert event.agent_id == "ingestion_agent"
         assert event.schema_version == "1.0"
         assert "batch_id" in event.payload
@@ -64,10 +64,10 @@ class TestIngestionAgent:
 ## Key Rules
 
 - **Mock external services.** Never make real API calls in tests: mock JSearch, Crawl4AI, Azure OpenAI, and MSSQL.
-- **Test event contracts.** Verify emitted events conform to `AgentEvent` schema with correct `agent_id`, `schema_version`, and expected payload keys.
+- **Test event contracts.** Verify emitted events conform to `EventEnvelope` schema with correct `agent_id`, `schema_version`, and expected payload keys.
 - **Test error paths.** Every agent must handle: source failure, LLM timeout, schema violation, DB error.
 - **Write tests alongside code.** Every new agent method or feature gets a corresponding test.
-- **Use fixtures** for common setup: sample `AgentEvent` objects, mock DB sessions, sample `JobRecord` data.
+- **Use fixtures** for common setup: sample `EventEnvelope` objects, mock DB sessions, sample `JobRecord` data.
 
 ## Evaluation Targets to Validate
 
@@ -88,7 +88,7 @@ Tests should verify these metric targets where applicable:
 ```python
 @pytest.fixture
 def sample_ingest_event():
-    return AgentEvent(
+    return EventEnvelope(
         correlation_id="test-correlation-123",
         agent_id="ingestion_agent",
         schema_version="1.0",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ The existing app is a Next.js/TypeScript/Prisma app. The agent pipeline is a **s
     │   ├── forecasting/
     │   └── tests/
     ├── common/
-    │   ├── events/            ← AgentEvent dataclass + all typed event definitions
+    │   ├── events/            ← EventEnvelope model + all typed event definitions
     │   ├── message_bus/       ← In-process Python pub/sub (Phase 1); bus-agnostic contracts
     │   ├── llm_adapter.py
     │   ├── data_store/

--- a/docs/planning/ARCHITECTURAL_DECISIONS.md
+++ b/docs/planning/ARCHITECTURAL_DECISIONS.md
@@ -72,7 +72,7 @@ weight it carries and who owns it.
 | 25 | Contract | Next.js / Python layer boundary | Prisma is Next.js-only — never imported or invoked from Python. Python agents access PostgreSQL via SQLAlchemy only |
 | 26 | Contract | Abstraction layer mandate | All swappable tools sit behind ABCs: `SourceAdapter`, `EventBusBase`, `TracerBase`, `AgentBase` |
 | 27 | Contract | Logging library | structlog — JSON format, keyword arguments, no PII in any log line |
-| 28 | Contract | Agent health interface | Every agent exposes `health_check() → bool` — returns True if all dependencies reachable, called by Orchestration Agent before scheduling |
+| 28 | Contract | Agent health interface | Every agent exposes `health_check() → dict` — returns `{"status": "ok"\|"degraded"\|"down", "agent": str, "last_run": str, "metrics": dict}`, called by Orchestration Agent before scheduling |
 | 29 | Contract | Correlation ID propagation | Set once at pipeline entry, propagated unchanged through every downstream event |
 | 30 | Contract | Taxonomy store abstraction | `TaxonomyStoreBase` ABC — concrete implementation switchable via `TAXONOMY_STORE` env var. Phase 1: `PostgreSQLTaxonomyStore`. Phase 2: `LightcastTaxonomyStore` |
 
@@ -380,7 +380,7 @@ are never logged, by any agent.
 | **Type** | Contract |
 | **Options** | No standard interface / `health_check()` on every agent |
 | **Status** | ✅ Resolved — Must resolve before Week 3 |
-| **Decision** | Every agent exposes `health_check() → bool`. Returns `True` if all dependencies reachable, `False` otherwise. The Orchestration Agent calls it before scheduling any run and aborts if any agent returns `False` |
+| **Decision** | Every agent exposes `health_check() → dict`. Returns `{"status": "ok"\|"degraded"\|"down", "agent": str, "last_run": str, "metrics": dict}`. The Orchestration Agent calls it before scheduling any run and aborts if any Phase 1 agent returns `status != "ok"` |
 
 **Rationale:** Without a standard health check, the Orchestration Agent has no
 way to know if a downstream agent is ready before committing resources to a run.

--- a/docs/planning/ARCHITECTURE_DEEP.md
+++ b/docs/planning/ARCHITECTURE_DEEP.md
@@ -138,10 +138,14 @@ log.info("ingestion_batch_complete", batch_id=batch_id, record_count=n, dedup_co
 ### Health check (required on every agent)
 
 ```python
-def health_check(self) -> bool:
-    """Return True only if all dependencies are reachable."""
-    # Check DB connection, fixture files, LLM connectivity as needed
-    return True
+def health_check(self) -> dict:
+    """Return a dict describing agent readiness."""
+    return {
+        "status": "ok",       # "ok" | "degraded" | "down"
+        "agent": self.agent_id,
+        "last_run": self.last_run_at.isoformat() if self.last_run_at else None,
+        "metrics": self.last_run_metrics,
+    }
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Fixes `health_check()` return type in docs from `-> bool` to `-> dict` (matching actual `BaseAgent` code)
- Renames `AgentEvent` to `EventEnvelope` across all doc references (matching `agents/common/event_envelope.py`)
- Updates `.cursor/rules/*.mdc` to reflect PostgreSQL (not MSSQL) for agent DB access

## Files changed
- `docs/planning/ARCHITECTURE_DEEP.md` — health_check → dict
- `docs/planning/ARCHITECTURAL_DECISIONS.md` — decision #28 → dict
- `CLAUDE.md` — AgentEvent → EventEnvelope
- `.cursor/rules/event-contracts.mdc` — AgentEvent → EventEnvelope
- `.cursor/rules/project-context.mdc` — AgentEvent → EventEnvelope, MSSQL → PostgreSQL
- `.cursor/rules/python-agent-patterns.mdc` — AgentEvent → EventEnvelope, MSSQL → PostgreSQL
- `.cursor/rules/testing-standards.mdc` — AgentEvent → EventEnvelope

## Test plan
- [x] `grep -r "AgentEvent" docs/ .cursor/ CLAUDE.md` returns 0 matches
- [x] `grep -r "health_check.*bool" docs/planning/` returns 0 matches in health_check contexts

🤖 Generated with [Claude Code](https://claude.com/claude-code)