### PR TITLE
Add Redis Docker service for agent event bus

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,9 @@ LANGCHAIN_TRACING_V2=true
 # The agent pipeline uses PostgreSQL; the Next.js app still uses MSSQL (a future DB-unification effort will consolidate both on PostgreSQL).
 PYTHON_DATABASE_URL=postgresql+psycopg2://postgres:YOUR_POSTGRES_PASSWORD@localhost:5432/talent_finder
 
+# Message bus (Redis Streams — inter-agent event communication)
+REDIS_URL=redis://localhost:6379/0
+
 # Ingestion
 JSEARCH_API_KEY=
 SCRAPING_TARGETS=                        # Comma-separated target URLs

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -33,6 +33,7 @@ Edit `.env` and set at minimum:
 |----------|-------------|
 | `AUTH_SECRET` | Generate with `openssl rand -base64 32` |
 | `PYTHON_DATABASE_URL` | PostgreSQL connection string (see step 5) |
+| `REDIS_URL` | Redis connection string — default: `redis://localhost:6379/0` |
 | `AZURE_OPENAI_ENDPOINT` | Azure OpenAI resource URL |
 | `AZURE_OPENAI_API_KEY` | Azure OpenAI API key |
 | `AZURE_OPENAI_API_VERSION` | e.g. `2025-01-01-preview` |
@@ -64,6 +65,7 @@ Edit `.env.docker` and set the PostgreSQL variables:
 | `POSTGRES_PASSWORD` | — | Strong password |
 | `POSTGRES_DB` | `talent_finder` | Database name |
 | `POSTGRES_PORT` | `5432` | Host port mapping |
+| `REDIS_PORT` | `6379` | Redis host port mapping |
 
 > **MSSQL variables** (`MSSQL_SA_PASSWORD`, `MSSQL_DATABASE`, `MSSQL_PORT`) are only needed if you run the legacy Next.js app — see [section 8](#8-optional-mssql--nextjs-setup).
 
@@ -84,6 +86,28 @@ docker ps --filter "name=postgres-server"
 You should see `(healthy)` in the STATUS column. The pgvector extension is automatically enabled on first container creation (via `scripts/postgres-init/01-enable-pgvector.sql`).
 
 See [docs/DOCKER_POSTGRESQL_SETUP.md](docs/DOCKER_POSTGRESQL_SETUP.md) for detailed setup, troubleshooting, and connection info.
+
+## 3.1 Start Redis (Docker)
+
+Redis Streams is the inter-agent message bus for the Job Intelligence Engine pipeline. Agents publish and consume typed events via `XADD`/`XREADGROUP`/`XACK`.
+
+```bash
+docker compose --env-file .env.docker up redis -d
+```
+
+Verify the container is healthy:
+
+```bash
+docker ps --filter "name=redis-server"
+```
+
+Test connectivity:
+
+```bash
+docker exec redis-server redis-cli ping
+```
+
+You should see `PONG`. Redis is configured with AOF persistence — data survives container restarts.
 
 ## 4. Python Environment Setup
 
@@ -287,6 +311,8 @@ If you need vector search (skill autocomplete), visit `/admin/dashboard/generate
 | `PYTHON_DATABASE_URL` connection fails | Ensure PostgreSQL container is running (`docker ps --filter "name=postgres-server"`), port matches `.env.docker`, password is correct |
 | `ERROR: Set PYTHON_DATABASE_URL` | Add `PYTHON_DATABASE_URL=postgresql+psycopg2://postgres:YourPassword@localhost:5432/talent_finder` to `.env` |
 | Port 5432 already in use | Change `POSTGRES_PORT` in `.env.docker` (e.g. to `15432`) and update `PYTHON_DATABASE_URL` |
+| Redis container won't start | Check Docker is running: `docker ps`. Check logs: `docker logs redis-server` |
+| Redis `PONG` test fails | Ensure Redis container is running and healthy: `docker ps --filter "name=redis-server"` |
 | `pip` not recognized / Python not found | Install Python 3.11, enable "Add python.exe to PATH", then use a venv (section 4). On Windows, use `py -3.11 -m venv .venv` and activate before running `pip` |
 | `SQLAlchemy OperationalError` | `DATABASE_URL` uses Prisma's `sqlserver://` format. Set `PYTHON_DATABASE_URL` using `postgresql+psycopg2://` format (see step 5) |
 | Docker not found | Install Docker — see [docs/INSTALL_DOCKER.md](docs/INSTALL_DOCKER.md) |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For a visual overview of the platform architecture (current and planned), see [d
 
 - Python >= 3.11 (for the agent pipeline)
 - npm
-- Docker (for local PostgreSQL)
+- Docker (for local PostgreSQL and Redis)
 
 ## Getting Started
 
@@ -33,6 +33,7 @@ cd watechcoalition
 - [Install Docker](docs/INSTALL_DOCKER.md)
 - [Branching Strategy](docs/branch-strategy.md)
 - [PostgreSQL Docker Setup](docs/DOCKER_POSTGRESQL_SETUP.md)
+- [Redis Setup](#redis-message-bus) — Redis Streams for inter-agent events
 - [Changing the DB schema](docs/prisma-workflow.md)
 - [API Routes](docs/API-routes.md)
 - [CSS Utilities & Styling Guide](docs/styling-guide.md)
@@ -84,6 +85,7 @@ python -m pytest agents/tests/ -v
 - **LangChain**: LLM adapter layer. [LangChain Documentation](https://python.langchain.com/)
 - **SQLAlchemy**: Python database access (PostgreSQL via psycopg2). [SQLAlchemy Documentation](https://docs.sqlalchemy.org/)
 - **Streamlit**: Read-only analytics dashboards. [Streamlit Documentation](https://docs.streamlit.io/)
+- **Redis Streams**: Inter-agent event bus (`XADD`/`XREADGROUP`/`XACK`). [Redis Streams Documentation](https://redis.io/docs/data-types/streams/)
 - **LangSmith**: Agent tracing and evaluation. [LangSmith Documentation](https://docs.smith.langchain.com/)
 
 ## License

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,8 +40,26 @@ services:
       start_period: 15s
     restart: unless-stopped
 
+  redis:
+    image: redis:7-alpine
+    container_name: redis-server
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    volumes:
+      - redis_data:/data
+    command: redis-server --appendonly yes
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+    restart: unless-stopped
+
 volumes:
   mssql_data:
     driver: local
   postgres_data:
+    driver: local
+  redis_data:
     driver: local


### PR DESCRIPTION
## Summary
- Add `redis:7-alpine` service to `docker-compose.yml` (port 6379, AOF persistence, healthcheck, named volume)
- Add `REDIS_URL` to `.env.example` in the Agent Pipeline section
- Update `README.md` prerequisites and tutorials with Redis references
- Add Section 3.1 to `ONBOARDING.md` with Redis setup, env vars, and troubleshooting

## Context
`redis>=5.0` was already in `agents/requirements.txt` but had no Docker container to run against. This adds the infrastructure so Bryan + Emilio's `RedisStreamsEventBus` (EXP-004 / ADR #14) has a local Redis instance.

## Test plan
- [ ] `docker compose --env-file .env.docker up redis -d` starts cleanly
- [ ] `docker exec redis-server redis-cli ping` returns `PONG`
- [ ] Existing PostgreSQL and MSSQL services unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)