### PR TITLE
Pin Python to 3.11 across all documentation

### DIFF
--- a/.cursor/rules/project-context.mdc
+++ b/.cursor/rules/project-context.mdc
@@ -10,7 +10,7 @@ alwaysApply: true
 Dual-stack repository:
 
 - **Root (`/`)** — Next.js / TypeScript / Prisma web application. **Read-only from the agent pipeline perspective.**
-- **`agents/`** — Python 3.11+ eight-agent pipeline that ingests, normalizes, enriches, and analyzes external job postings. **This is the active development focus.**
+- **`agents/`** — Python 3.11 (pinned) eight-agent pipeline that ingests, normalizes, enriches, and analyzes external job postings. **This is the active development focus.**
 
 ## Canonical Documentation
 
@@ -45,7 +45,7 @@ Unless explicitly instructed, never modify files outside `agents/`:
 
 | Layer | Technology |
 |-------|-----------|
-| Runtime | Python 3.11+ |
+| Runtime | Python 3.11 (pinned) |
 | Multi-agent framework | LangGraph (StateGraph) |
 | LLM adapter | LangChain + Azure OpenAI (provider-agnostic via `LLM_PROVIDER` env var) |
 | Tracing | LangSmith |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ Sources (JSearch API via httpx / Web scraping via Crawl4AI)
 
 | Layer | Technology | Decision |
 |-------|-----------|---------|
-| Agent runtime | Python 3.11+ | — |
+| Agent runtime | Python 3.11 (pinned) | — |
 | Multi-agent framework | LangGraph StateGraph | SA #13 |
 | LLM adapter | LangChain + Azure OpenAI (provider-agnostic) | SA #11 |
 | LLM provider default | Azure OpenAI; switchable via `LLM_PROVIDER` env var | SA #11 |

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -5,7 +5,7 @@ This guide walks through setting up the watechcoalition platform after cloning t
 ## Prerequisites
 
 - **Node.js** 18.17 or later ([nodejs.org](https://nodejs.org/) or use [nvm](https://github.com/nvm-sh/nvm))
-- **Python** 3.11 or later — [python.org/downloads](https://www.python.org/downloads/); on Windows, enable **"Add python.exe to PATH"** during install
+- **Python 3.11** (pinned — do not use 3.12+) — [python.org/downloads](https://www.python.org/downloads/); on Windows, enable **"Add python.exe to PATH"** during install
 - **Docker** (for local PostgreSQL) — see [docs/INSTALL_DOCKER.md](docs/INSTALL_DOCKER.md)
 - **Git**
 
@@ -89,7 +89,7 @@ See [docs/DOCKER_POSTGRESQL_SETUP.md](docs/DOCKER_POSTGRESQL_SETUP.md) for detai
 
 ### 4.1 Install Python 3.11 (if not already installed)
 
-1. Download from [python.org/downloads](https://www.python.org/downloads/) (Python 3.11 or later).
+1. Download from [python.org/downloads](https://www.python.org/downloads/) (**Python 3.11 specifically** — do not use 3.12+; a dependency requires 3.11).
 2. Run the installer. **On Windows**, check **"Add python.exe to PATH"**.
 3. Verify:
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For a visual overview of the platform architecture (current and planned), see [d
 
 - Node.js >= 18.17.0
 
-- Python >= 3.11 (for the agent pipeline)
+- Python 3.11 (pinned — for the agent pipeline)
 - npm
 - Docker (for local PostgreSQL)
 


### PR DESCRIPTION
## Summary
- Pin Python version to 3.11 (not 3.11+) across CLAUDE.md, README.md, ONBOARDING.md, and Cursor rules
- A dependency requires Python 3.11 specifically — 3.12+ is not supported
- CI workflow (`.github/workflows/build.yml`) already uses `python-version: "3.11"`

## Files changed
- `.cursor/rules/project-context.mdc` — 3.11+ → 3.11 (pinned)
- `CLAUDE.md` — 3.11+ → 3.11 (pinned)
- `README.md` — >= 3.11 → 3.11 (pinned)
- `ONBOARDING.md` — explicit "do not use 3.12+" language

## Test plan
- [ ] Verify CI still uses python-version: "3.11" (already does)
- [ ] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)