### PR TITLE
fix: Week 03 post-merge spec compliance

### DIFF
--- a/agents/common/data_store/models.py
+++ b/agents/common/data_store/models.py
@@ -84,8 +84,9 @@ class RawIngestedJob(Base):
     # Processing state
     processing_status: Mapped[str] = mapped_column(String(50), default="pending")
     error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
-    ingestion_timestamp: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    date_ingested: Mapped[datetime] = mapped_column(
+        "ingestion_timestamp",
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc),
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)

--- a/agents/normalization/agent.py
+++ b/agents/normalization/agent.py
@@ -349,7 +349,9 @@ class NormalizationAgent(AgentBase):
         return "normalization-agent"
 
     def health_check(self) -> dict:
-        """Check DB connectivity."""
+        """Check DB connectivity and mapper availability."""
+        from agents.normalization.mappers import MAPPER_REGISTRY
+
         db_ok = check_db_connection()
         return {
             "status": "healthy" if db_ok else "degraded",
@@ -357,6 +359,7 @@ class NormalizationAgent(AgentBase):
             "last_run": None,
             "metrics": {},
             "db_reachable": db_ok,
+            "mappers_registered": list(MAPPER_REGISTRY.keys()),
         }
 
     def process(self, event: EventEnvelope) -> EventEnvelope:

--- a/agents/pipeline_runner.py
+++ b/agents/pipeline_runner.py
@@ -50,6 +50,10 @@ _REPO_ROOT = Path(__file__).parent.parent
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
+from dotenv import load_dotenv  # noqa: E402
+
+load_dotenv(_REPO_ROOT / ".env")
+
 import structlog  # noqa: E402
 
 from agents.analytics.agent import AnalyticsAgent  # noqa: E402


### PR DESCRIPTION
## Summary
- Add `mappers_registered` key to normalization agent `health_check()` — lists registered source mappers from `MAPPER_REGISTRY`
- Rename `ingestion_timestamp` Python attribute to `date_ingested` on `RawIngestedJob` model (DB column name `ingestion_timestamp` preserved via explicit column name for backward compatibility)
- Add `dotenv.load_dotenv()` to `pipeline_runner.py` so `.env` is loaded automatically on pipeline start

## Test plan
- [x] `python -m pytest agents/tests/ -v` — 83 passed, 11 skipped
- [x] `ruff check agents/` — clean
- [ ] CI `python-tests` workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)