### PR TITLE
chore: Azure PostgreSQL env setup + dbo schema guard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,7 +58,15 @@ LANGCHAIN_TRACING_V2=true
 # Python agent database connection (SQLAlchemy + psycopg2 → PostgreSQL)
 # IMPORTANT: This is different from DATABASE_URL above (which uses Prisma's sqlserver:// syntax for the Next.js app).
 # The agent pipeline uses PostgreSQL; the Next.js app still uses MSSQL (a future DB-unification effort will consolidate both on PostgreSQL).
-PYTHON_DATABASE_URL=postgresql+psycopg2://postgres:YOUR_POSTGRES_PASSWORD@localhost:5432/talent_finder
+#
+# Option A — Local Docker PostgreSQL:
+# PYTHON_DATABASE_URL=postgresql+psycopg2://postgres:YOUR_POSTGRES_PASSWORD@localhost:5432/talent_finder
+#
+# Option B — Azure PostgreSQL (recommended for class):
+PYTHON_DATABASE_URL=postgresql+psycopg2://azadmin:<password>@pg-jobintel-cfa-dev.postgres.database.azure.com:5432/talent_finder?sslmode=require
+
+# Convenience alias — same Azure URL for scripts that reference this name
+AZURE_POSTGRES_DATABASE_URL=postgresql+psycopg2://azadmin:<password>@pg-jobintel-cfa-dev.postgres.database.azure.com:5432/talent_finder?sslmode=require
 
 # Message bus (Redis Streams — inter-agent event communication)
 REDIS_URL=redis://localhost:6379/0

--- a/agents/common/data_store/migrations.py
+++ b/agents/common/data_store/migrations.py
@@ -37,6 +37,10 @@ def run_migrations(engine: Engine) -> None:
     """Create agent tables and add Phase 1 columns. Safe to run multiple times."""
     log.info("migrations_start")
 
+    # 0. Ensure the dbo schema exists (required by ORM models)
+    with engine.begin() as conn:
+        conn.execute(text("CREATE SCHEMA IF NOT EXISTS dbo"))
+
     # 1. Create agent-managed tables via SQLAlchemy metadata
     Base.metadata.create_all(engine)
     log.info("migrations_tables_created")


### PR DESCRIPTION
## Summary
- Update `.env.example` with Option A (local Docker) / Option B (Azure PostgreSQL) pattern for `PYTHON_DATABASE_URL`
- Add `AZURE_POSTGRES_DATABASE_URL` convenience alias placeholder
- Add `CREATE SCHEMA IF NOT EXISTS dbo` to `migrations.py` before `Base.metadata.create_all()` — makes agent migrations self-sufficient

## Test plan
- [x] `python -m pytest agents/tests/ -v` — 83 passed, 11 skipped
- [ ] CI `python-tests` workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)