### PR TITLE
fix: normalization state key + health check status values

### DIFF
--- a/agents/ingestion/agent.py
+++ b/agents/ingestion/agent.py
@@ -335,11 +335,11 @@ class IngestionAgent(AgentBase):
         fixture_ok = (Path(__file__).parent.parent / "data" / "fixtures" / "fallback_scrape_sample.json").exists()
 
         if db_ok and fixture_ok:
-            status = "healthy"
+            status = "ok"
         elif db_ok or fixture_ok:
             status = "degraded"
         else:
-            status = "unhealthy"
+            status = "down"
 
         return {
             "status": status,
@@ -435,6 +435,9 @@ def _quarantine_to_file(run_id: str, record: dict, error: str) -> None:
 def _cli() -> None:
     """CLI for running the Ingestion Agent standalone."""
     import argparse
+
+    from dotenv import load_dotenv
+    load_dotenv()
 
     parser = argparse.ArgumentParser(description="Run the Ingestion Agent")
     parser.add_argument("--source", choices=["jsearch", "crawl4ai", "all"], default="all")

--- a/agents/normalization/agent.py
+++ b/agents/normalization/agent.py
@@ -354,7 +354,7 @@ class NormalizationAgent(AgentBase):
 
         db_ok = check_db_connection()
         return {
-            "status": "healthy" if db_ok else "degraded",
+            "status": "ok" if db_ok else "degraded",
             "agent": self.agent_id,
             "last_run": None,
             "metrics": {},

--- a/agents/normalization/state.py
+++ b/agents/normalization/state.py
@@ -19,3 +19,4 @@ class NormalizationState(TypedDict, total=False):
     status: str
     errors: list[str]
     normalization_complete_event: dict
+    _pending_records: list[dict]


### PR DESCRIPTION
## Summary
Fixes discovered during live runbook walkthrough:

- **Add `_pending_records` to `NormalizationState` TypedDict** — LangGraph was silently dropping this key because it wasn't in the state schema, causing normalization to fetch 43 records but normalize 0. This was a critical bug.
- **Fix health_check status values** — changed from `"healthy"/"unhealthy"` to `"ok"/"down"` to match the spec in CLAUDE.md
- **Add `dotenv.load_dotenv()` to ingestion CLI** — `python -m agents.ingestion.agent` now loads `.env` automatically

## Test plan
- [x] `python -m pytest agents/tests/ -v` — 83 passed, 11 skipped, 0 failed
- [x] `ruff check agents/` — clean
- [x] Live walkthrough: 43 records ingested → 43 normalized → 0 quarantined → 0 duplicates
- [ ] CI `python-tests` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)