### PR TITLE
fix: prettier formatting in jobseekerSlice.ts

### DIFF
--- a/lib/features/profileCreation/jobseekerSlice.ts
+++ b/lib/features/profileCreation/jobseekerSlice.ts
@@ -19,8 +19,10 @@ import {
   TimeUntilCompletion,
 } from "@/app/lib/admin/careerPrep";
 
-interface JsEducationPageBlankHighestLevelDTO
-  extends Omit<JsEducationPageDTO, "highestLevelOfStudy"> {
+interface JsEducationPageBlankHighestLevelDTO extends Omit<
+  JsEducationPageDTO,
+  "highestLevelOfStudy"
+> {
   highestLevelOfStudy: HighestCompletedEducationLevel | "";
 }
 


### PR DESCRIPTION
## Summary
- Fixes `npm run build` CI failure caused by prettier formatting mismatch
- The `extends Omit<...>` declaration in `jobseekerSlice.ts` is formatted differently by prettier 3.8.1 (what CI resolves to) vs older versions
- Reformatted to match latest prettier output

## Root cause
No `package-lock.json` exists, so CI's `npm install` resolves `prettier ^3.3.3` to the latest 3.x (currently 3.8.1). Prettier 3.8.1 changed how multi-line `extends` clauses are formatted.

## Test plan
- [x] `npx prettier@3.8.1 --check lib/features/profileCreation/jobseekerSlice.ts` passes
- [x] CI `build` (`npm run build`) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)