### PR TITLE
fix: make ContextSignal.source_span required (SpanRecord, not Optional)

### DIFF
--- a/agents/common/types/extraction_types.py
+++ b/agents/common/types/extraction_types.py
@@ -78,7 +78,7 @@ class ContextSignal(BaseModel):
     signal_type: str  # remote_policy | team_size | reporting_structure | growth_stage | ai_usage
     value: str
     confidence: float = Field(ge=0.0, le=1.0)
-    field_source: str
+    source_span: SpanRecord  # required — links extraction back to source text
 
 
 class TaxonomyResult(BaseModel):

--- a/docs/planning/ARCHITECTURE_DEEP.md
+++ b/docs/planning/ARCHITECTURE_DEEP.md
@@ -206,7 +206,7 @@ class ContextSignal(BaseModel):
     signal_type: str              # remote_policy | team_size | reporting_structure | growth_stage | ai_usage
     value: str
     confidence: float
-    source_span: Optional[SpanRecord]
+    source_span: SpanRecord
 
 class ExtractionMetadata(BaseModel):
     extraction_version: str


### PR DESCRIPTION
## Summary
- `ContextSignal.source_span` is now a required `SpanRecord` field (was `Optional[SpanRecord]` in ARCHITECTURE_DEEP.md, and missing entirely from `extraction_types.py`)
- Removes `field_source` from `ContextSignal` in `extraction_types.py` — that field now lives inside `SpanRecord.field_source`, so every extraction links back to source text with full span evidence
- Aligns with curriculum-planning PR #27

## Files changed
- `agents/common/types/extraction_types.py` — replaced `field_source: str` with `source_span: SpanRecord` (required)
- `docs/planning/ARCHITECTURE_DEEP.md` — changed `source_span: Optional[SpanRecord]` to `source_span: SpanRecord`

## Test plan
- [ ] Verify existing tests that construct `ContextSignal` now pass a `SpanRecord` instead of a `field_source` string
- [ ] Confirm fixture data in `tests/` is updated to include `source_span` for any `ContextSignal` instances

🤖 Generated with [Claude Code](https://claude.com/claude-code)