### PR TITLE
tools: add ground truth labeling helper app

### DIFF
--- a/agents/common/types/extraction_types.py
+++ b/agents/common/types/extraction_types.py
@@ -21,8 +21,8 @@ class SpanRecord(BaseModel):
 
     text: str
     field_source: str  # title | description | requirements | responsibilities
-    char_start: int
-    char_end: int
+    start_char: int
+    end_char: int
 
 
 class SkillRecord(BaseModel):

--- a/agents/common/types/extraction_types.py
+++ b/agents/common/types/extraction_types.py
@@ -43,7 +43,7 @@ class ToolRecord(BaseModel):
     """A single extracted tool (programming language, framework, platform, etc.)."""
 
     tool_id: str | None = None
-    label: str
+    tool_name: str
     category: str  # language | framework | platform | database | devops | ai_tool | other
     confidence: float = Field(ge=0.0, le=1.0)
     field_source: str

--- a/tools/ground-truth-labeler/.env.example
+++ b/tools/ground-truth-labeler/.env.example
@@ -1,0 +1,5 @@
+# Ground Truth Labeler — Environment Variables
+# Copy this file to .env and fill in your values.
+
+# RapidAPI key for JSearch (same key used by the ingestion agent)
+JSEARCH_API_KEY=

--- a/tools/ground-truth-labeler/.gitignore
+++ b/tools/ground-truth-labeler/.gitignore
@@ -1,0 +1,2 @@
+jsearch_cache.json
+ground_truth_labeled.json

--- a/tools/ground-truth-labeler/.gitignore
+++ b/tools/ground-truth-labeler/.gitignore
@@ -1,2 +1,3 @@
 jsearch_cache.json
 ground_truth_labeled.json
+venv/

--- a/tools/ground-truth-labeler/README.md
+++ b/tools/ground-truth-labeler/README.md
@@ -2,7 +2,7 @@
 
 A lightweight Streamlit app for hand-labeling job postings with `SkillRecord` and `ToolRecord` annotations that conform to the `extraction_types.py` Pydantic models.
 
-## Quick Start
+## Setup
 
 ```bash
 cd tools/ground-truth-labeler
@@ -10,12 +10,20 @@ python -m venv venv
 venv\Scripts\activate      # Windows
 # source venv/bin/activate # macOS/Linux
 pip install -r requirements.txt
+# If pip is not recognized, use:
+# python -m pip install -r requirements.txt
+cp .env.example .env       # add your JSEARCH_API_KEY
+```
+
+## Run
+
+```bash
 python -m streamlit run app.py
 ```
 
 ## Environment
 
-The JSearch search tab requires a RapidAPI key in your environment:
+The JSearch search tab requires a RapidAPI key in your `.env` file:
 
 ```
 JSEARCH_API_KEY=your_rapidapi_key_here
@@ -27,13 +35,22 @@ This is the same key used by the ingestion agent. If unset, use the Manual Entry
 
 1. **Search & Select** — Search JSearch for real El Paso postings, or paste text manually
 2. **Review** — Read the job posting split by section (title, description, requirements, responsibilities)
-3. **Label Skills** — Add SkillRecords with type, confidence, field_source, GenAI flag
-4. **Label Tools** — Add ToolRecords with category, confidence, GenAI tool flag
-5. **Review & Export** — Validate against Pydantic, add to dataset, export JSON
+3. **Label Skills** — Highlight text to capture `source_span`, then fill in skill label, type, confidence, GenAI flag
+4. **Label Tools** — Same drag-to-select flow for tools with category and GenAI tool flag
+5. **Review & Save** — Validate against Pydantic, preview JSON, append to dataset
 
-## Output Format
+## Features
 
-Exported JSON matches the `SkillRecord` and `ToolRecord` shapes from `extraction_types.py` (PR #64 schema). Each record can be loaded directly with Pydantic for validation.
+- **Drag-to-select source_span** — highlight text to auto-capture `field_source`, `start_char`, `end_char`, and evidence text
+- **Split-pane layout** — form on left, independently scrollable job text on right
+- **JSearch caching** — results cached locally, survives refresh
+- **Dark mode** support
+- **UTF-8 mojibake fix** for JSearch API responses
+
+## Design Decisions
+
+- `SpanRecord.text` captures the evidence phrase; skill/tool label is user-typed (supports inferred skills from surrounding context)
+- `SpanRecord` offsets validated by Pydantic (`end_char - start_char == len(text)`, `start_char >= 0`)
 
 ## Labeling Examples
 
@@ -41,7 +58,7 @@ See [ground-truth-examples.md](ground-truth-examples.md) for 5 hand-labeled exam
 
 ## Target Dataset
 
-20-30 labeled postings covering:
-- Traditional roles (no AI/ML) — at least 5-8
-- GenAI-focused roles (~30-40% of dataset)
+20–30 labeled postings covering:
+- Traditional roles (no AI/ML) — at least 5–8
+- GenAI-focused roles (~30–40% of dataset)
 - Ambiguous items (Excel, leadership, Python)

--- a/tools/ground-truth-labeler/README.md
+++ b/tools/ground-truth-labeler/README.md
@@ -6,8 +6,11 @@ A lightweight Streamlit app for hand-labeling job postings with `SkillRecord` an
 
 ```bash
 cd tools/ground-truth-labeler
+python -m venv venv
+venv\Scripts\activate      # Windows
+# source venv/bin/activate # macOS/Linux
 pip install -r requirements.txt
-streamlit run app.py
+python -m streamlit run app.py
 ```
 
 ## Environment

--- a/tools/ground-truth-labeler/README.md
+++ b/tools/ground-truth-labeler/README.md
@@ -1,0 +1,40 @@
+# Ground Truth Labeling Tool
+
+A lightweight Streamlit app for hand-labeling job postings with `SkillRecord` and `ToolRecord` annotations that conform to the `extraction_types.py` Pydantic models.
+
+## Quick Start
+
+```bash
+cd tools/ground-truth-labeler
+pip install -r requirements.txt
+streamlit run app.py
+```
+
+## Environment
+
+The JSearch search tab requires a RapidAPI key in your environment:
+
+```
+JSEARCH_API_KEY=your_rapidapi_key_here
+```
+
+This is the same key used by the ingestion agent. If unset, use the Manual Entry tab instead.
+
+## Workflow
+
+1. **Search & Select** — Search JSearch for real El Paso postings, or paste text manually
+2. **Review** — Read the job posting split by section (title, description, requirements, responsibilities)
+3. **Label Skills** — Add SkillRecords with type, confidence, field_source, GenAI flag
+4. **Label Tools** — Add ToolRecords with category, confidence, GenAI tool flag
+5. **Review & Export** — Validate against Pydantic, add to dataset, export JSON
+
+## Output Format
+
+Exported JSON matches the `SkillRecord` and `ToolRecord` shapes from `extraction_types.py` (PR #64 schema). Each record can be loaded directly with Pydantic for validation.
+
+## Target Dataset
+
+20-30 labeled postings covering:
+- Traditional roles (no AI/ML) — at least 5-8
+- GenAI-focused roles (~30-40% of dataset)
+- Ambiguous items (Excel, leadership, Python)

--- a/tools/ground-truth-labeler/README.md
+++ b/tools/ground-truth-labeler/README.md
@@ -35,6 +35,10 @@ This is the same key used by the ingestion agent. If unset, use the Manual Entry
 
 Exported JSON matches the `SkillRecord` and `ToolRecord` shapes from `extraction_types.py` (PR #64 schema). Each record can be loaded directly with Pydantic for validation.
 
+## Labeling Examples
+
+See [ground-truth-examples.md](ground-truth-examples.md) for 5 hand-labeled examples showing the expected format, schema conventions, and labeler notes. Use these as a reference when labeling new records.
+
 ## Target Dataset
 
 20-30 labeled postings covering:

--- a/tools/ground-truth-labeler/app.py
+++ b/tools/ground-truth-labeler/app.py
@@ -377,7 +377,7 @@ elif st.session_state.phase == "label":
         # =================================================================
 
         if st.session_state.label_step == "review":
-            col1, col2 = st.columns(2)
+            col1, col2, _ = st.columns([1, 1, 8])
             with col1:
                 if st.button("⏭️ Skip this job"):
                     st.session_state.job_index += 1
@@ -388,7 +388,7 @@ elif st.session_state.phase == "label":
                     set_label_step("review")
                     st.rerun()
             with col2:
-                if st.button("Label Skills →"):
+                if st.button("Label Job Post →"):
                     reset_labels()
                     set_label_step("skills")
                     st.rerun()
@@ -401,7 +401,7 @@ elif st.session_state.phase == "label":
 
         elif st.session_state.label_step == "skills":
             # Tab-like navigation
-            nav1, nav2, nav3, nav4 = st.columns(4)
+            nav1, nav2, nav3, nav4, _ = st.columns([1, 1, 1, 1, 6])
             with nav1:
                 if st.button("← Review", key="nav_review_from_skills"):
                     set_label_step("review")
@@ -567,7 +567,7 @@ elif st.session_state.phase == "label":
 
         elif st.session_state.label_step == "tools":
             # Tab-like navigation
-            nav1, nav2, nav3, nav4 = st.columns(4)
+            nav1, nav2, nav3, nav4, _ = st.columns([1, 1, 1, 1, 6])
             with nav1:
                 if st.button("← Review", key="nav_review_from_tools"):
                     set_label_step("review")

--- a/tools/ground-truth-labeler/app.py
+++ b/tools/ground-truth-labeler/app.py
@@ -400,6 +400,23 @@ elif st.session_state.phase == "label":
         # =================================================================
 
         elif st.session_state.label_step == "skills":
+            # Tab-like navigation
+            nav1, nav2, nav3, nav4 = st.columns(4)
+            with nav1:
+                if st.button("← Review", key="nav_review_from_skills"):
+                    set_label_step("review")
+                    st.rerun()
+            with nav2:
+                st.button("🎯 Skills", key="nav_skills_active", disabled=True)
+            with nav3:
+                if st.button("🔧 Tools", key="nav_tools_from_skills"):
+                    set_label_step("tools")
+                    st.rerun()
+            with nav4:
+                if st.button("💾 Save →", key="nav_save_from_skills"):
+                    set_label_step("save")
+                    st.rerun()
+
             left, right = st.columns([1, 1])
 
             with right:
@@ -544,22 +561,28 @@ elif st.session_state.phase == "label":
                                 st.session_state.pop("editing_skill_index", None)
                                 st.rerun()
 
-                st.divider()
-                bc1, bc2 = st.columns(2)
-                with bc1:
-                    if st.button("← Back to Review"):
-                        set_label_step("review")
-                        st.rerun()
-                with bc2:
-                    if st.button("Label Tools →"):
-                        set_label_step("tools")
-                        st.rerun()
-
         # =================================================================
         # LABEL STEP: Tools — left pane form, right pane job text
         # =================================================================
 
         elif st.session_state.label_step == "tools":
+            # Tab-like navigation
+            nav1, nav2, nav3, nav4 = st.columns(4)
+            with nav1:
+                if st.button("← Review", key="nav_review_from_tools"):
+                    set_label_step("review")
+                    st.rerun()
+            with nav2:
+                if st.button("🎯 Skills", key="nav_skills_from_tools"):
+                    set_label_step("skills")
+                    st.rerun()
+            with nav3:
+                st.button("🔧 Tools", key="nav_tools_active", disabled=True)
+            with nav4:
+                if st.button("💾 Save →", key="nav_save_from_tools"):
+                    set_label_step("save")
+                    st.rerun()
+
             left, right = st.columns([1, 1])
 
             with right:
@@ -697,17 +720,6 @@ elif st.session_state.phase == "label":
                                 st.session_state.tools.pop(i)
                                 st.session_state.pop("editing_tool_index", None)
                                 st.rerun()
-
-                st.divider()
-                bc1, bc2 = st.columns(2)
-                with bc1:
-                    if st.button("← Back to Skills"):
-                        set_label_step("skills")
-                        st.rerun()
-                with bc2:
-                    if st.button("Review & Save →"):
-                        set_label_step("save")
-                        st.rerun()
 
         # =================================================================
         # LABEL STEP: Save

--- a/tools/ground-truth-labeler/app.py
+++ b/tools/ground-truth-labeler/app.py
@@ -179,6 +179,26 @@ def reset_labels() -> None:
 
 st.set_page_config(page_title="Ground Truth Labeler", page_icon="🏷️", layout="wide")
 
+# CSS: independent scrolling for left (form) and right (job text) columns
+st.markdown("""
+<style>
+/* The horizontal block containing the labeling columns:
+   kill flex-grow so height constraint is respected */
+[data-testid="stHorizontalBlock"]:has(.gt-section) {
+    height: calc(100vh - 260px) !important;
+    flex: 0 0 calc(100vh - 260px) !important;
+    overflow: hidden !important;
+    align-items: stretch !important;
+    flex-wrap: nowrap !important;
+}
+/* Both columns: independent scroll */
+[data-testid="stHorizontalBlock"]:has(.gt-section) > [data-testid="stColumn"] {
+    overflow-y: auto !important;
+    height: 100% !important;
+}
+</style>
+""", unsafe_allow_html=True)
+
 # --- Sidebar: dataset status + labeled items for current job ---
 dataset = load_dataset()
 with st.sidebar:

--- a/tools/ground-truth-labeler/app.py
+++ b/tools/ground-truth-labeler/app.py
@@ -1,0 +1,695 @@
+"""Ground Truth Labeling Tool — Streamlit App.
+
+Batch workflow: Search 10 jobs → label all sequentially → auto-append to
+ground_truth_labeled.json after each record.
+
+Layout: Left pane = forms + labeled items | Right pane = scrollable job text
+JSearch results cached to jsearch_cache.json so you can reload without re-calling the API.
+
+Usage:
+    cd tools/ground-truth-labeler
+    python -m streamlit run app.py
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).parent / ".env")
+
+import streamlit as st
+
+from jsearch_client import get_api_key, parse_job_sections, search_jobs
+from schema import (
+    GENAI_SKILLS,
+    GroundTruthRecord,
+    SkillRecord,
+    SpanRecord,
+    ToolRecord,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+OUTPUT_FILE = Path(__file__).parent / "ground_truth_labeled.json"
+CACHE_FILE = Path(__file__).parent / "jsearch_cache.json"
+
+
+# ---------------------------------------------------------------------------
+# File I/O helpers
+# ---------------------------------------------------------------------------
+
+
+def load_dataset() -> list[dict]:
+    """Load existing dataset from disk, or return empty list."""
+    if OUTPUT_FILE.exists():
+        try:
+            return json.loads(OUTPUT_FILE.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, ValueError):
+            return []
+    return []
+
+
+def save_dataset(dataset: list[dict]) -> None:
+    """Write the full dataset to disk."""
+    OUTPUT_FILE.write_text(
+        json.dumps(dataset, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+
+def next_gt_id(dataset: list[dict]) -> str:
+    """Generate the next ground_truth_id based on existing records."""
+    return f"gt-{len(dataset) + 1:03d}"
+
+
+def load_cache() -> dict:
+    """Load cached JSearch results from disk."""
+    if CACHE_FILE.exists():
+        try:
+            return json.loads(CACHE_FILE.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, ValueError):
+            return {}
+    return {}
+
+
+def save_cache(query: str, jobs: list[dict], job_index: int = 0) -> None:
+    """Save JSearch results and current position to disk cache."""
+    CACHE_FILE.write_text(
+        json.dumps({"query": query, "jobs": jobs, "job_index": job_index}, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+
+def clear_cache() -> None:
+    """Delete the cache file."""
+    if CACHE_FILE.exists():
+        CACHE_FILE.unlink()
+
+
+# ---------------------------------------------------------------------------
+# Job text rendering helper (used in right pane)
+# ---------------------------------------------------------------------------
+
+SECTION_COLORS = {
+    "title": "rgba(33, 150, 243, 0.15)",
+    "description": "rgba(156, 39, 176, 0.15)",
+    "requirements": "rgba(76, 175, 80, 0.15)",
+    "responsibilities": "rgba(255, 152, 0, 0.15)",
+}
+
+
+def render_job_text(job: dict) -> None:
+    """Render color-coded job text sections in a scrollable container."""
+    sections = [
+        ("title", "Title", job.get("title", "")),
+        ("description", "Description", job.get("description", "")),
+        ("requirements", "Requirements", job.get("requirements", "")),
+        ("responsibilities", "Responsibilities", job.get("responsibilities", "")),
+    ]
+    for field_source, label, text in sections:
+        if text.strip():
+            bg = SECTION_COLORS.get(field_source, "#f5f5f5")
+            st.markdown(
+                f'<div style="background:{bg}; padding:10px; border-radius:6px; '
+                f'margin-bottom:6px;">'
+                f"<strong>📌 {label}</strong> "
+                f'<code style="font-size:0.75em;">field_source="{field_source}"</code>'
+                f"<br/><pre style='white-space:pre-wrap; font-size:0.85em; "
+                f"max-height:none; color:inherit;'>{text[:4000]}</pre>"
+                f"</div>",
+                unsafe_allow_html=True,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Session state defaults
+# ---------------------------------------------------------------------------
+
+# --- Auto-load from cache BEFORE setting defaults ---
+if "phase" not in st.session_state:
+    # First run — initialize everything
+    _cached = load_cache()
+    _cached_jobs = _cached.get("jobs", [])
+    _cached_index = _cached.get("job_index", 0)
+
+    st.session_state.phase = "label" if _cached_jobs else "search"
+    st.session_state.jobs = _cached_jobs
+    st.session_state.job_index = _cached_index
+    st.session_state.label_step = "review"
+    st.session_state.skills = []
+    st.session_state.tools = []
+    st.session_state.labeler_notes = {}
+elif not st.session_state.get("jobs"):
+    # Session exists but jobs are empty — try cache reload
+    _cached = load_cache()
+    _cached_jobs = _cached.get("jobs", [])
+    if _cached_jobs:
+        st.session_state.jobs = _cached_jobs
+        st.session_state.job_index = _cached.get("job_index", 0)
+        st.session_state.phase = "label"
+        st.session_state.label_step = "review"
+
+
+def set_phase(phase: str) -> None:
+    st.session_state.phase = phase
+
+
+def set_label_step(step: str) -> None:
+    st.session_state.label_step = step
+
+
+def reset_labels() -> None:
+    st.session_state.skills = []
+    st.session_state.tools = []
+    st.session_state.labeler_notes = {}
+    st.session_state.pop("editing_skill_index", None)
+    st.session_state.pop("editing_tool_index", None)
+
+
+# ---------------------------------------------------------------------------
+# Page config
+# ---------------------------------------------------------------------------
+
+st.set_page_config(page_title="Ground Truth Labeler", page_icon="🏷️", layout="wide")
+
+# --- Sidebar: dataset status + labeled items for current job ---
+dataset = load_dataset()
+with st.sidebar:
+    st.header("📊 Dataset")
+    st.metric("Records saved", len(dataset))
+    st.caption("Target: 20-30 records")
+    st.caption(f"File: `{OUTPUT_FILE.name}`")
+
+    # Show labeled skills/tools for current job
+    if st.session_state.phase == "label" and st.session_state.label_step in ("skills", "tools", "save"):
+        st.divider()
+        st.subheader("Current Job Labels")
+        if st.session_state.skills:
+            st.markdown(f"**Skills ({len(st.session_state.skills)})**")
+            for skill in st.session_state.skills:
+                badge = " 🤖" if skill.is_genai_extension else ""
+                st.markdown(f"- {skill.label}{badge} *({skill.type})*")
+        if st.session_state.tools:
+            st.markdown(f"**Tools ({len(st.session_state.tools)})**")
+            for tool in st.session_state.tools:
+                badge = " 🤖" if tool.is_genai_tool else ""
+                st.markdown(f"- {tool.tool_name}{badge} *({tool.category})*")
+
+    # Saved records
+    if dataset:
+        st.divider()
+        st.subheader("Saved Records")
+        for rec in dataset:
+            st.markdown(
+                f"**{rec['ground_truth_id']}** — {rec['title'][:25]}  \n"
+                f"{len(rec.get('skills', []))}S / {len(rec.get('tools', []))}T"
+            )
+
+    st.divider()
+    cached = load_cache()
+    if cached.get("query"):
+        st.caption(f"Cached query: *{cached['query']}*")
+    if st.button("🔄 New Search"):
+        clear_cache()
+        st.session_state.phase = "search"
+        st.session_state.jobs = []
+        st.session_state.job_index = 0
+        reset_labels()
+        st.rerun()
+
+
+# =========================================================================
+# PHASE: SEARCH — Load a batch of jobs
+# =========================================================================
+
+if st.session_state.phase == "search":
+    st.title("🏷️ Ground Truth Labeling Tool")
+    st.header("Step 1 — Search & Load Job Batch")
+
+    tab_search, tab_manual = st.tabs(["🔍 JSearch API", "📝 Manual Entry"])
+
+    with tab_search:
+        api_key = get_api_key()
+        if not api_key:
+            st.warning(
+                "No `JSEARCH_API_KEY` found in environment. "
+                "Set it in your `.env` file or switch to Manual Entry."
+            )
+        else:
+            st.success("JSearch API key detected.")
+
+        query = st.text_input(
+            "Search query",
+            value="data engineer El Paso TX",
+            help="Try: 'software engineer El Paso', 'AI engineer remote', etc.",
+        )
+        num_results = st.slider("Jobs to load", 1, 10, 10)
+
+        if st.button("🔎 Search & Load All", disabled=not api_key):
+            with st.spinner("Searching JSearch..."):
+                results = search_jobs(query, num_results)
+                if results and "error" not in results[0]:
+                    parsed = [parse_job_sections(j) for j in results]
+                    # Save to cache (flush old, write new)
+                    save_cache(query, parsed)
+                    st.session_state.jobs = parsed
+                    st.session_state.job_index = 0
+                    reset_labels()
+                    set_phase("label")
+                    set_label_step("review")
+                    st.rerun()
+                else:
+                    st.error(f"Search failed: {results}")
+
+    with tab_manual:
+        st.markdown("Paste job posting details manually (no API key needed).")
+        with st.form("manual_form"):
+            m_title = st.text_input("Job Title")
+            m_company = st.text_input("Company")
+            col1, col2 = st.columns(2)
+            with col1:
+                m_city = st.text_input("City", value="El Paso")
+            with col2:
+                m_state = st.text_input("State", value="TX")
+            m_description = st.text_area("Description", height=200)
+            m_requirements = st.text_area("Requirements", height=150)
+            m_responsibilities = st.text_area("Responsibilities", height=150)
+            submitted = st.form_submit_button("Add to batch")
+            if submitted and m_title:
+                job = {
+                    "external_id": f"manual-{uuid.uuid4().hex[:8]}",
+                    "title": m_title,
+                    "company": m_company,
+                    "city": m_city,
+                    "state": m_state,
+                    "description": m_description,
+                    "requirements": m_requirements,
+                    "responsibilities": m_responsibilities,
+                    "job_url": "",
+                    "is_remote": False,
+                    "employment_type": "",
+                }
+                st.session_state.jobs.append(job)
+                st.success(f"Added. Batch now has {len(st.session_state.jobs)} job(s).")
+
+        if st.session_state.jobs:
+            st.divider()
+            st.subheader(f"Batch ({len(st.session_state.jobs)} jobs)")
+            for i, j in enumerate(st.session_state.jobs):
+                st.markdown(f"{i+1}. **{j['title']}** — {j['company']}")
+            if st.button("▶️ Start Labeling Batch"):
+                save_cache("manual", st.session_state.jobs)
+                st.session_state.job_index = 0
+                reset_labels()
+                set_phase("label")
+                set_label_step("review")
+                st.rerun()
+
+
+# =========================================================================
+# PHASE: LABEL — Cycle through each job in the batch
+# =========================================================================
+
+elif st.session_state.phase == "label":
+    jobs = st.session_state.jobs
+    idx = st.session_state.job_index
+
+    if idx >= len(jobs):
+        st.title("🏷️ Ground Truth Labeling Tool")
+        st.success(f"✅ All {len(jobs)} jobs in this batch have been labeled!")
+        st.info(f"Dataset now has **{len(load_dataset())}** total records in `{OUTPUT_FILE.name}`.")
+        if st.button("🔍 Search for more jobs"):
+            clear_cache()
+            set_phase("search")
+            st.session_state.jobs = []
+            st.session_state.job_index = 0
+            st.rerun()
+    else:
+        job = jobs[idx]
+
+        # --- Progress bar ---
+        st.title("🏷️ Ground Truth Labeling Tool")
+        prog_col1, prog_col2 = st.columns([3, 1])
+        with prog_col1:
+            st.progress(idx / len(jobs), text=f"Job {idx + 1} of {len(jobs)}")
+        with prog_col2:
+            step_labels = {
+                "review": "📖 Review",
+                "skills": "🎯 Skills",
+                "tools": "🔧 Tools",
+                "save": "💾 Save",
+            }
+            st.markdown(f"**{step_labels.get(st.session_state.label_step, '')}**")
+
+        st.markdown(f"### {job['title']} — {job['company']}")
+        st.caption(f"{job.get('city', '')}, {job.get('state', '')} | ID: {job['external_id']}")
+        st.divider()
+
+        # =================================================================
+        # LABEL STEP: Review (full width — read through before labeling)
+        # =================================================================
+
+        if st.session_state.label_step == "review":
+            render_job_text(job)
+
+            st.divider()
+            col1, col2 = st.columns(2)
+            with col1:
+                if st.button("⏭️ Skip this job"):
+                    st.session_state.job_index += 1
+                    cached = load_cache()
+                    if cached.get("jobs"):
+                        save_cache(cached.get("query", ""), cached["jobs"], st.session_state.job_index)
+                    reset_labels()
+                    set_label_step("review")
+                    st.rerun()
+            with col2:
+                if st.button("Label Skills →"):
+                    reset_labels()
+                    set_label_step("skills")
+                    st.rerun()
+
+        # =================================================================
+        # LABEL STEP: Skills — left pane form, right pane job text
+        # =================================================================
+
+        elif st.session_state.label_step == "skills":
+            left, right = st.columns([1, 1])
+
+            with right:
+                st.markdown("#### 📄 Job Text")
+                render_job_text(job)
+                with st.expander("ℹ️ GenAI Extension Skills (10-skill list)"):
+                    for s in GENAI_SKILLS:
+                        st.markdown(f"- {s}")
+
+            with left:
+                # --- Determine if editing ---
+                editing_idx = st.session_state.get("editing_skill_index")
+                editing_skill = st.session_state.skills[editing_idx] if editing_idx is not None else None
+                fs_options = ["requirements", "description", "responsibilities", "title"]
+
+                if editing_skill:
+                    st.markdown(f"#### ✏️ Edit Skill: {editing_skill.label}")
+                else:
+                    st.markdown("#### 🎯 Add Skill")
+
+                with st.form("skill_form", clear_on_submit=True):
+                    s_label = st.text_input(
+                        "Skill label",
+                        value=editing_skill.label if editing_skill else "",
+                        help="e.g. Python, Prompt Engineering",
+                    )
+                    c1, c2 = st.columns(2)
+                    with c1:
+                        s_type = st.selectbox(
+                            "Type",
+                            ["Technical", "Domain", "Soft", "Certification", "Tool"],
+                            index=["Technical", "Domain", "Soft", "Certification", "Tool"].index(editing_skill.type) if editing_skill else 0,
+                        )
+                        s_required = st.checkbox("Required?", value=editing_skill.required_flag if editing_skill and editing_skill.required_flag is not None else True)
+                    with c2:
+                        s_field_source = st.selectbox(
+                            "field_source *",
+                            fs_options,
+                            index=fs_options.index(editing_skill.source_span.field_source) if editing_skill else None,
+                            placeholder="Select section...",
+                        )
+                        s_genai = st.checkbox("GenAI Extension skill?", value=editing_skill.is_genai_extension if editing_skill else False)
+                    s_esco = st.text_input("ESCO URI (optional)", value=editing_skill.esco_uri or "" if editing_skill else "")
+                    s_note = st.text_input(
+                        "Labeler note (optional)",
+                        value=st.session_state.labeler_notes.get(editing_skill.label, "") if editing_skill else "",
+                    )
+                    s_confidence = st.slider("Confidence", 0.0, 1.0, editing_skill.confidence if editing_skill else 1.0, 0.05)
+
+                    btn_label = "💾 Save Skill" if editing_skill else "➕ Add Skill"
+                    submitted = st.form_submit_button(btn_label)
+                    if submitted:
+                        if not s_label.strip():
+                            st.error("Skill label is required.")
+                        elif s_field_source is None:
+                            st.error("field_source is required — select which section the skill appears in.")
+                        else:
+                            label = s_label.strip()
+                            skill = SkillRecord(
+                                label=label,
+                                type=s_type,
+                                confidence=s_confidence,
+                                required_flag=s_required,
+                                esco_uri=s_esco.strip() or None,
+                                is_genai_extension=s_genai,
+                                source_span=SpanRecord(
+                                    text=label,
+                                    field_source=s_field_source,
+                                    start_char=0,
+                                    end_char=len(label),
+                                ),
+                            )
+                            if editing_idx is not None:
+                                # Overwrite the existing skill
+                                st.session_state.skills[editing_idx] = skill
+                                st.session_state.pop("editing_skill_index", None)
+                            else:
+                                st.session_state.skills.append(skill)
+                            if s_note.strip():
+                                st.session_state.labeler_notes[label] = s_note.strip()
+                            st.rerun()
+
+                # Cancel edit button
+                if editing_idx is not None:
+                    if st.button("Cancel edit"):
+                        st.session_state.pop("editing_skill_index", None)
+                        st.rerun()
+
+                # Show current skills
+                if st.session_state.skills:
+                    st.markdown(f"**Skills added ({len(st.session_state.skills)})**")
+                    for i, skill in enumerate(st.session_state.skills):
+                        sc1, sc2, sc3 = st.columns([4, 1, 1])
+                        with sc1:
+                            badge = " 🤖" if skill.is_genai_extension else ""
+                            st.markdown(
+                                f"- **{skill.label}**{badge} — {skill.type} "
+                                f"(`{skill.source_span.field_source}`)"
+                            )
+                        with sc2:
+                            if st.button("✏️", key=f"es_{i}"):
+                                st.session_state.editing_skill_index = i
+                                st.rerun()
+                        with sc3:
+                            if st.button("🗑️", key=f"ds_{i}"):
+                                st.session_state.skills.pop(i)
+                                st.session_state.pop("editing_skill_index", None)
+                                st.rerun()
+
+                st.divider()
+                bc1, bc2 = st.columns(2)
+                with bc1:
+                    if st.button("← Back to Review"):
+                        set_label_step("review")
+                        st.rerun()
+                with bc2:
+                    if st.button("Label Tools →"):
+                        set_label_step("tools")
+                        st.rerun()
+
+        # =================================================================
+        # LABEL STEP: Tools — left pane form, right pane job text
+        # =================================================================
+
+        elif st.session_state.label_step == "tools":
+            left, right = st.columns([1, 1])
+
+            with right:
+                st.markdown("#### 📄 Job Text")
+                render_job_text(job)
+
+            with left:
+                # --- Determine if editing ---
+                editing_tidx = st.session_state.get("editing_tool_index")
+                editing_tool = st.session_state.tools[editing_tidx] if editing_tidx is not None else None
+                fs_options = ["requirements", "description", "responsibilities", "title"]
+                cat_options = ["language", "framework", "platform", "database", "devops", "ai_tool", "other"]
+
+                if editing_tool:
+                    st.markdown(f"#### ✏️ Edit Tool: {editing_tool.tool_name}")
+                else:
+                    st.markdown("#### 🔧 Add Tool")
+
+                with st.form("tool_form", clear_on_submit=True):
+                    t_name = st.text_input(
+                        "Tool name",
+                        value=editing_tool.tool_name if editing_tool else "",
+                        help="e.g. Apache Spark, Docker, Pinecone",
+                    )
+                    c1, c2 = st.columns(2)
+                    with c1:
+                        t_category = st.selectbox(
+                            "Category",
+                            cat_options,
+                            index=cat_options.index(editing_tool.category) if editing_tool else None,
+                            placeholder="Select category...",
+                        )
+                    with c2:
+                        t_field_source = st.selectbox(
+                            "field_source *",
+                            fs_options,
+                            index=fs_options.index(editing_tool.source_span.field_source) if editing_tool else None,
+                            placeholder="Select section...",
+                        )
+                    t_genai = st.checkbox("GenAI tool?", value=editing_tool.is_genai_tool if editing_tool else False, help="Pinecone, LangChain, OpenAI API, etc.")
+                    t_note = st.text_input(
+                        "Labeler note (optional)",
+                        value=st.session_state.labeler_notes.get(editing_tool.tool_name, "") if editing_tool else "",
+                    )
+                    t_confidence = st.slider("Confidence", 0.0, 1.0, editing_tool.confidence if editing_tool else 1.0, 0.05)
+
+                    btn_label = "💾 Save Tool" if editing_tool else "➕ Add Tool"
+                    submitted = st.form_submit_button(btn_label)
+                    if submitted:
+                        if not t_name.strip():
+                            st.error("Tool name is required.")
+                        elif t_field_source is None:
+                            st.error("field_source is required — select which section the tool appears in.")
+                        elif t_category is None:
+                            st.error("Category is required.")
+                        else:
+                            name = t_name.strip()
+                            tool = ToolRecord(
+                                tool_name=name,
+                                category=t_category,
+                                confidence=t_confidence,
+                                is_genai_tool=t_genai,
+                                source_span=SpanRecord(
+                                    text=name,
+                                    field_source=t_field_source,
+                                    start_char=0,
+                                    end_char=len(name),
+                                ),
+                            )
+                            if editing_tidx is not None:
+                                st.session_state.tools[editing_tidx] = tool
+                                st.session_state.pop("editing_tool_index", None)
+                            else:
+                                st.session_state.tools.append(tool)
+                            if t_note.strip():
+                                st.session_state.labeler_notes[name] = t_note.strip()
+                            st.rerun()
+
+                # Cancel edit button
+                if editing_tidx is not None:
+                    if st.button("Cancel edit", key="cancel_tool_edit"):
+                        st.session_state.pop("editing_tool_index", None)
+                        st.rerun()
+
+                # Show current tools
+                if st.session_state.tools:
+                    st.markdown(f"**Tools added ({len(st.session_state.tools)})**")
+                    for i, tool in enumerate(st.session_state.tools):
+                        tc1, tc2, tc3 = st.columns([4, 1, 1])
+                        with tc1:
+                            badge = " 🤖" if tool.is_genai_tool else ""
+                            st.markdown(
+                                f"- **{tool.tool_name}**{badge} — {tool.category} "
+                                f"(`{tool.source_span.field_source}`)"
+                            )
+                        with tc2:
+                            if st.button("✏️", key=f"et_{i}"):
+                                st.session_state.editing_tool_index = i
+                                st.rerun()
+                        with tc3:
+                            if st.button("🗑️", key=f"dt_{i}"):
+                                st.session_state.tools.pop(i)
+                                st.session_state.pop("editing_tool_index", None)
+                                st.rerun()
+
+                st.divider()
+                bc1, bc2 = st.columns(2)
+                with bc1:
+                    if st.button("← Back to Skills"):
+                        set_label_step("skills")
+                        st.rerun()
+                with bc2:
+                    if st.button("Review & Save →"):
+                        set_label_step("save")
+                        st.rerun()
+
+        # =================================================================
+        # LABEL STEP: Save
+        # =================================================================
+
+        elif st.session_state.label_step == "save":
+            dataset = load_dataset()
+            gt_id = next_gt_id(dataset)
+
+            record = GroundTruthRecord(
+                ground_truth_id=gt_id,
+                external_id=job.get("external_id", ""),
+                title=job["title"],
+                company=job["company"],
+                city=job.get("city"),
+                state=job.get("state"),
+                description=job.get("description", ""),
+                requirements=job.get("requirements", ""),
+                responsibilities=job.get("responsibilities", ""),
+                skills=st.session_state.skills,
+                tools=st.session_state.tools,
+                labeler_notes=st.session_state.labeler_notes,
+            )
+
+            record_dict = record.model_dump()
+
+            # Validation
+            try:
+                GroundTruthRecord.model_validate(record_dict)
+                st.success("✅ Pydantic validation passed")
+            except Exception as exc:
+                st.error(f"❌ Validation failed: {exc}")
+
+            # Summary
+            col1, col2, col3 = st.columns(3)
+            with col1:
+                st.metric("Skills", len(record.skills))
+            with col2:
+                st.metric("Tools", len(record.tools))
+            with col3:
+                st.metric("Dataset after save", len(dataset) + 1)
+
+            # JSON preview
+            with st.expander("JSON Preview", expanded=True):
+                st.json(record_dict)
+
+            st.divider()
+            col1, col2, col3 = st.columns(3)
+
+            with col1:
+                if st.button("← Back to Tools"):
+                    set_label_step("tools")
+                    st.rerun()
+
+            with col2:
+                if st.button("⏭️ Skip (don't save)"):
+                    st.session_state.job_index += 1
+                    reset_labels()
+                    set_label_step("review")
+                    st.rerun()
+
+            with col3:
+                if st.button("💾 Save & Next Job", type="primary"):
+                    dataset.append(record_dict)
+                    save_dataset(dataset)
+                    st.session_state.job_index += 1
+                    # Persist position to cache so refresh resumes here
+                    cached = load_cache()
+                    if cached.get("jobs"):
+                        save_cache(cached.get("query", ""), cached["jobs"], st.session_state.job_index)
+                    reset_labels()
+                    set_label_step("review")
+                    st.rerun()

--- a/tools/ground-truth-labeler/app.py
+++ b/tools/ground-truth-labeler/app.py
@@ -357,9 +357,6 @@ elif st.session_state.phase == "label":
         # =================================================================
 
         if st.session_state.label_step == "review":
-            render_job_text(job)
-
-            st.divider()
             col1, col2 = st.columns(2)
             with col1:
                 if st.button("⏭️ Skip this job"):
@@ -375,6 +372,8 @@ elif st.session_state.phase == "label":
                     reset_labels()
                     set_label_step("skills")
                     st.rerun()
+            st.divider()
+            render_job_text(job)
 
         # =================================================================
         # LABEL STEP: Skills — left pane form, right pane job text

--- a/tools/ground-truth-labeler/app.py
+++ b/tools/ground-truth-labeler/app.py
@@ -215,7 +215,7 @@ with st.sidebar:
             st.markdown(f"**Skills ({len(st.session_state.skills)})**")
             for skill in st.session_state.skills:
                 badge = " 🤖" if skill.is_genai_extension else ""
-                st.markdown(f"- {skill.label}{badge} *({skill.type})*")
+                st.markdown(f"- {skill.skill_name}{badge} *({skill.type})*")
         if st.session_state.tools:
             st.markdown(f"**Tools ({len(st.session_state.tools)})**")
             for tool in st.session_state.tools:
@@ -439,7 +439,7 @@ elif st.session_state.phase == "label":
                 editing_skill = st.session_state.skills[editing_idx] if editing_idx is not None else None
 
                 if editing_skill:
-                    st.markdown(f"#### ✏️ Edit Skill: {editing_skill.label}")
+                    st.markdown(f"#### ✏️ Edit Skill: {editing_skill.skill_name}")
                 else:
                     st.markdown("#### 🎯 Add Skill")
 
@@ -473,14 +473,14 @@ elif st.session_state.phase == "label":
                     span_end = None
                     st.warning("No span selected — drag text in the right pane to set source_span.")
 
-                # Determine default label from span selection or editing
-                default_label = editing_skill.label if editing_skill else ""
+                # Determine default skill_name from editing
+                default_name = editing_skill.skill_name if editing_skill else ""
 
                 with st.form("skill_form", clear_on_submit=True):
                     s_label = st.text_input(
-                        "Skill label",
-                        value=default_label,
-                        help="e.g. Python, Prompt Engineering. Drag text on the right to auto-fill.",
+                        "Skill name",
+                        value=default_name,
+                        help="e.g. Python, Prompt Engineering. The human-judged skill label.",
                     )
                     c1, c2 = st.columns(2)
                     with c1:
@@ -495,7 +495,7 @@ elif st.session_state.phase == "label":
                     s_esco = st.text_input("ESCO URI (optional)", value=editing_skill.esco_uri or "" if editing_skill else "")
                     s_note = st.text_input(
                         "Labeler note (optional)",
-                        value=st.session_state.labeler_notes.get(editing_skill.label, "") if editing_skill else "",
+                        value=st.session_state.labeler_notes.get(editing_skill.skill_name, "") if editing_skill else "",
                     )
                     s_confidence = st.slider("Confidence", 0.0, 1.0, editing_skill.confidence if editing_skill else 1.0, 0.05)
 
@@ -503,13 +503,13 @@ elif st.session_state.phase == "label":
                     submitted = st.form_submit_button(btn_label)
                     if submitted:
                         if not s_label.strip():
-                            st.error("Skill label is required.")
+                            st.error("Skill name is required.")
                         elif span_field is None:
                             st.error("Source span is required — drag to select text in the right pane first.")
                         else:
-                            label = s_label.strip()
+                            skill_name = s_label.strip()
                             skill = SkillRecord(
-                                label=label,
+                                skill_name=skill_name,
                                 type=s_type,
                                 confidence=s_confidence,
                                 required_flag=s_required,
@@ -528,7 +528,7 @@ elif st.session_state.phase == "label":
                             else:
                                 st.session_state.skills.append(skill)
                             if s_note.strip():
-                                st.session_state.labeler_notes[label] = s_note.strip()
+                                st.session_state.labeler_notes[skill_name] = s_note.strip()
                             # Clear span selection after use
                             st.session_state.pop("span_selection", None)
                             st.rerun()
@@ -548,7 +548,7 @@ elif st.session_state.phase == "label":
                             badge = " 🤖" if skill.is_genai_extension else ""
                             sp = skill.source_span
                             st.markdown(
-                                f"- **{skill.label}**{badge} — {skill.type} "
+                                f"- **{skill.skill_name}**{badge} — {skill.type} "
                                 f"(`{sp.field_source}` [{sp.start_char}:{sp.end_char}])"
                             )
                         with sc2:

--- a/tools/ground-truth-labeler/app.py
+++ b/tools/ground-truth-labeler/app.py
@@ -31,6 +31,7 @@ from schema import (
     SpanRecord,
     ToolRecord,
 )
+from text_selector import render_selectable_job_text, span_input_bridge
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -384,27 +385,66 @@ elif st.session_state.phase == "label":
 
             with right:
                 st.markdown("#### 📄 Job Text")
-                render_job_text(job)
+                st.caption("💡 Highlight text to capture source_span automatically")
+                render_selectable_job_text(job, bridge_key="skill_span_bridge")
+                span_result = span_input_bridge(key="skill_span_bridge")
+                if span_result:
+                    st.session_state.span_selection = span_result
                 with st.expander("ℹ️ GenAI Extension Skills (10-skill list)"):
                     for s in GENAI_SKILLS:
                         st.markdown(f"- {s}")
 
             with left:
+                # --- Get span selection (if any) ---
+                span_sel = st.session_state.get("span_selection")
+
                 # --- Determine if editing ---
                 editing_idx = st.session_state.get("editing_skill_index")
                 editing_skill = st.session_state.skills[editing_idx] if editing_idx is not None else None
-                fs_options = ["requirements", "description", "responsibilities", "title"]
 
                 if editing_skill:
                     st.markdown(f"#### ✏️ Edit Skill: {editing_skill.label}")
                 else:
                     st.markdown("#### 🎯 Add Skill")
 
+                # --- Source Span section (from selection or editing) ---
+                st.markdown("##### 📌 Source Span")
+                if editing_skill:
+                    sp = editing_skill.source_span
+                    span_text = sp.text
+                    span_field = sp.field_source
+                    span_start = sp.start_char
+                    span_end = sp.end_char
+                    st.success(
+                        f"**field_source:** `{span_field}` | "
+                        f"**start_char:** {span_start} | **end_char:** {span_end}  \n"
+                        f"**text:** *\"{span_text[:80]}{'...' if len(span_text) > 80 else ''}\"*"
+                    )
+                elif span_sel:
+                    span_text = span_sel["text"]
+                    span_field = span_sel["field_source"]
+                    span_start = span_sel["start_char"]
+                    span_end = span_sel["end_char"]
+                    st.success(
+                        f"**field_source:** `{span_field}` | "
+                        f"**start_char:** {span_start} | **end_char:** {span_end}  \n"
+                        f"**text:** *\"{span_text[:80]}{'...' if len(span_text) > 80 else ''}\"*"
+                    )
+                else:
+                    span_text = None
+                    span_field = None
+                    span_start = None
+                    span_end = None
+                    st.warning("No span selected — drag text in the right pane to set source_span.")
+
+                # Determine default label from span selection or editing
+                default_label = editing_skill.label if editing_skill else ""
+
                 with st.form("skill_form", clear_on_submit=True):
                     s_label = st.text_input(
                         "Skill label",
-                        value=editing_skill.label if editing_skill else "",
-                        help="e.g. Python, Prompt Engineering",
+                        value=default_label,
+                        help="e.g. Python, Prompt Engineering. Drag text on the right to auto-fill.",
                     )
                     c1, c2 = st.columns(2)
                     with c1:
@@ -415,12 +455,6 @@ elif st.session_state.phase == "label":
                         )
                         s_required = st.checkbox("Required?", value=editing_skill.required_flag if editing_skill and editing_skill.required_flag is not None else True)
                     with c2:
-                        s_field_source = st.selectbox(
-                            "field_source *",
-                            fs_options,
-                            index=fs_options.index(editing_skill.source_span.field_source) if editing_skill else None,
-                            placeholder="Select section...",
-                        )
                         s_genai = st.checkbox("GenAI Extension skill?", value=editing_skill.is_genai_extension if editing_skill else False)
                     s_esco = st.text_input("ESCO URI (optional)", value=editing_skill.esco_uri or "" if editing_skill else "")
                     s_note = st.text_input(
@@ -434,8 +468,8 @@ elif st.session_state.phase == "label":
                     if submitted:
                         if not s_label.strip():
                             st.error("Skill label is required.")
-                        elif s_field_source is None:
-                            st.error("field_source is required — select which section the skill appears in.")
+                        elif span_field is None:
+                            st.error("Source span is required — drag to select text in the right pane first.")
                         else:
                             label = s_label.strip()
                             skill = SkillRecord(
@@ -446,20 +480,21 @@ elif st.session_state.phase == "label":
                                 esco_uri=s_esco.strip() or None,
                                 is_genai_extension=s_genai,
                                 source_span=SpanRecord(
-                                    text=label,
-                                    field_source=s_field_source,
-                                    start_char=0,
-                                    end_char=len(label),
+                                    text=span_text,
+                                    field_source=span_field,
+                                    start_char=span_start,
+                                    end_char=span_end,
                                 ),
                             )
                             if editing_idx is not None:
-                                # Overwrite the existing skill
                                 st.session_state.skills[editing_idx] = skill
                                 st.session_state.pop("editing_skill_index", None)
                             else:
                                 st.session_state.skills.append(skill)
                             if s_note.strip():
                                 st.session_state.labeler_notes[label] = s_note.strip()
+                            # Clear span selection after use
+                            st.session_state.pop("span_selection", None)
                             st.rerun()
 
                 # Cancel edit button
@@ -475,9 +510,10 @@ elif st.session_state.phase == "label":
                         sc1, sc2, sc3 = st.columns([4, 1, 1])
                         with sc1:
                             badge = " 🤖" if skill.is_genai_extension else ""
+                            sp = skill.source_span
                             st.markdown(
                                 f"- **{skill.label}**{badge} — {skill.type} "
-                                f"(`{skill.source_span.field_source}`)"
+                                f"(`{sp.field_source}` [{sp.start_char}:{sp.end_char}])"
                             )
                         with sc2:
                             if st.button("✏️", key=f"es_{i}"):
@@ -509,13 +545,19 @@ elif st.session_state.phase == "label":
 
             with right:
                 st.markdown("#### 📄 Job Text")
-                render_job_text(job)
+                st.caption("💡 Highlight text to capture source_span automatically")
+                render_selectable_job_text(job, bridge_key="tool_span_bridge")
+                span_result = span_input_bridge(key="tool_span_bridge")
+                if span_result:
+                    st.session_state.span_selection = span_result
 
             with left:
+                # --- Get span selection (if any) ---
+                span_sel = st.session_state.get("span_selection")
+
                 # --- Determine if editing ---
                 editing_tidx = st.session_state.get("editing_tool_index")
                 editing_tool = st.session_state.tools[editing_tidx] if editing_tidx is not None else None
-                fs_options = ["requirements", "description", "responsibilities", "title"]
                 cat_options = ["language", "framework", "platform", "database", "devops", "ai_tool", "other"]
 
                 if editing_tool:
@@ -523,27 +565,51 @@ elif st.session_state.phase == "label":
                 else:
                     st.markdown("#### 🔧 Add Tool")
 
+                # --- Source Span section (from selection or editing) ---
+                st.markdown("##### 📌 Source Span")
+                if editing_tool:
+                    sp = editing_tool.source_span
+                    span_text = sp.text
+                    span_field = sp.field_source
+                    span_start = sp.start_char
+                    span_end = sp.end_char
+                    st.success(
+                        f"**field_source:** `{span_field}` | "
+                        f"**start_char:** {span_start} | **end_char:** {span_end}  \n"
+                        f"**text:** *\"{span_text[:80]}{'...' if len(span_text) > 80 else ''}\"*"
+                    )
+                elif span_sel:
+                    span_text = span_sel["text"]
+                    span_field = span_sel["field_source"]
+                    span_start = span_sel["start_char"]
+                    span_end = span_sel["end_char"]
+                    st.success(
+                        f"**field_source:** `{span_field}` | "
+                        f"**start_char:** {span_start} | **end_char:** {span_end}  \n"
+                        f"**text:** *\"{span_text[:80]}{'...' if len(span_text) > 80 else ''}\"*"
+                    )
+                else:
+                    span_text = None
+                    span_field = None
+                    span_start = None
+                    span_end = None
+                    st.warning("No span selected — drag text in the right pane to set source_span.")
+
+                # Determine default name from span selection or editing
+                default_name = editing_tool.tool_name if editing_tool else ""
+
                 with st.form("tool_form", clear_on_submit=True):
                     t_name = st.text_input(
                         "Tool name",
-                        value=editing_tool.tool_name if editing_tool else "",
-                        help="e.g. Apache Spark, Docker, Pinecone",
+                        value=default_name,
+                        help="e.g. Apache Spark, Docker, Pinecone. Drag text on the right to auto-fill.",
                     )
-                    c1, c2 = st.columns(2)
-                    with c1:
-                        t_category = st.selectbox(
-                            "Category",
-                            cat_options,
-                            index=cat_options.index(editing_tool.category) if editing_tool else None,
-                            placeholder="Select category...",
-                        )
-                    with c2:
-                        t_field_source = st.selectbox(
-                            "field_source *",
-                            fs_options,
-                            index=fs_options.index(editing_tool.source_span.field_source) if editing_tool else None,
-                            placeholder="Select section...",
-                        )
+                    t_category = st.selectbox(
+                        "Category",
+                        cat_options,
+                        index=cat_options.index(editing_tool.category) if editing_tool else None,
+                        placeholder="Select category...",
+                    )
                     t_genai = st.checkbox("GenAI tool?", value=editing_tool.is_genai_tool if editing_tool else False, help="Pinecone, LangChain, OpenAI API, etc.")
                     t_note = st.text_input(
                         "Labeler note (optional)",
@@ -556,8 +622,8 @@ elif st.session_state.phase == "label":
                     if submitted:
                         if not t_name.strip():
                             st.error("Tool name is required.")
-                        elif t_field_source is None:
-                            st.error("field_source is required — select which section the tool appears in.")
+                        elif span_field is None:
+                            st.error("Source span is required — drag to select text in the right pane first.")
                         elif t_category is None:
                             st.error("Category is required.")
                         else:
@@ -568,10 +634,10 @@ elif st.session_state.phase == "label":
                                 confidence=t_confidence,
                                 is_genai_tool=t_genai,
                                 source_span=SpanRecord(
-                                    text=name,
-                                    field_source=t_field_source,
-                                    start_char=0,
-                                    end_char=len(name),
+                                    text=span_text,
+                                    field_source=span_field,
+                                    start_char=span_start,
+                                    end_char=span_end,
                                 ),
                             )
                             if editing_tidx is not None:
@@ -581,6 +647,8 @@ elif st.session_state.phase == "label":
                                 st.session_state.tools.append(tool)
                             if t_note.strip():
                                 st.session_state.labeler_notes[name] = t_note.strip()
+                            # Clear span selection after use
+                            st.session_state.pop("span_selection", None)
                             st.rerun()
 
                 # Cancel edit button
@@ -596,9 +664,10 @@ elif st.session_state.phase == "label":
                         tc1, tc2, tc3 = st.columns([4, 1, 1])
                         with tc1:
                             badge = " 🤖" if tool.is_genai_tool else ""
+                            sp = tool.source_span
                             st.markdown(
                                 f"- **{tool.tool_name}**{badge} — {tool.category} "
-                                f"(`{tool.source_span.field_source}`)"
+                                f"(`{sp.field_source}` [{sp.start_char}:{sp.end_char}])"
                             )
                         with tc2:
                             if st.button("✏️", key=f"et_{i}"):

--- a/tools/ground-truth-labeler/ground-truth-examples.md
+++ b/tools/ground-truth-labeler/ground-truth-examples.md
@@ -40,7 +40,7 @@ Paste these into `agents/eval/extraction_ground_truth.json` as the starting arra
     "responsibilities": "Design and implement scalable data pipelines using Python and Apache Spark. Optimize SQL queries and database performance. Collaborate with data scientists and analysts to deliver clean datasets. Maintain documentation for data architecture decisions. Mentor junior engineers on best practices.",
     "skills": [
       {
-        "label": "Python",
+        "skill_name": "Python",
         "type": "Technical",
         "confidence": 1.0,
         "required_flag": true,
@@ -55,7 +55,7 @@ Paste these into `agents/eval/extraction_ground_truth.json` as the starting arra
         "labeler_note": "Ambiguous — could be Tool. Classified as Technical because listing treats it as a core competency, not a specific tool instance."
       },
       {
-        "label": "SQL",
+        "skill_name": "SQL",
         "type": "Technical",
         "confidence": 1.0,
         "required_flag": true,
@@ -70,7 +70,7 @@ Paste these into `agents/eval/extraction_ground_truth.json` as the starting arra
         "labeler_note": null
       },
       {
-        "label": "Data Modeling",
+        "skill_name": "Data Modeling",
         "type": "Domain",
         "confidence": 1.0,
         "required_flag": true,
@@ -85,7 +85,7 @@ Paste these into `agents/eval/extraction_ground_truth.json` as the starting arra
         "labeler_note": "No direct ESCO match — expect step 6 (raw_skill). Enrichment phase may resolve."
       },
       {
-        "label": "Data Warehousing",
+        "skill_name": "Data Warehousing",
         "type": "Domain",
         "confidence": 1.0,
         "required_flag": true,
@@ -100,7 +100,7 @@ Paste these into `agents/eval/extraction_ground_truth.json` as the starting arra
         "labeler_note": null
       },
       {
-        "label": "ETL",
+        "skill_name": "ETL",
         "type": "Technical",
         "confidence": 1.0,
         "required_flag": true,
@@ -115,7 +115,7 @@ Paste these into `agents/eval/extraction_ground_truth.json` as the starting arra
         "labeler_note": "Acronym — agent should expand or match as-is."
       },
       {
-        "label": "Communication",
+        "skill_name": "Communication",
         "type": "Soft",
         "confidence": 1.0,
         "required_flag": false,
@@ -130,7 +130,7 @@ Paste these into `agents/eval/extraction_ground_truth.json` as the starting arra
         "labeler_note": "Inferred from 'communicate technical concepts to non-technical stakeholders'. Not listed as a requirement."
       },
       {
-        "label": "Mentoring",
+        "skill_name": "Mentoring",
         "type": "Soft",
         "confidence": 1.0,
         "required_flag": false,
@@ -145,7 +145,7 @@ Paste these into `agents/eval/extraction_ground_truth.json` as the starting arra
         "labeler_note": "From 'Mentor junior engineers'. Soft skill, not explicit requirement."
       },
       {
-        "label": "Excel",
+        "skill_name": "Excel",
         "type": "Tool",
         "confidence": 1.0,
         "required_flag": true,
@@ -246,7 +246,7 @@ Paste these into `agents/eval/extraction_ground_truth.json` as the starting arra
     "responsibilities": "Build and maintain RAG pipelines for document Q&A systems. Manage Pinecone vector database clusters and embedding pipelines. Develop prompt templates and evaluate LLM output quality. Containerize and deploy ML models using Docker and Kubernetes. Implement AI output validation checks and guardrails. Collaborate with data scientists on foundation model selection for new use cases.",
     "skills": [
       {
-        "label": "Prompt Engineering",
+        "skill_name": "Prompt Engineering",
         "type": "Technical",
         "confidence": 1.0,
         "required_flag": true,
@@ -261,7 +261,7 @@ Paste these into `agents/eval/extraction_ground_truth.json` as the starting arra
         "labeler_note": "GenAI Extension Layer skill #1 → maps to ESCO 'Digital content creation' parent cluster."
       },
       {
-        "label": "RAG (Retrieval-Augmented Generation)",
+        "skill_name": "RAG (Retrieval-Augmented Generation)",
         "type": "Technical",
         "confidence": 1.0,
         "required_flag": true,
@@ -276,7 +276,7 @@ Paste these into `agents/eval/extraction_ground_truth.json` as the starting arra
         "labeler_note": "GenAI Extension Layer skill #2 → maps to ESCO 'Information retrieval' parent cluster."
       },
       {
-        "label": "AI Output Validation",
+        "skill_name": "AI Output Validation",
         "type": "Technical",
         "confidence": 1.0,
         "required_flag": false,
@@ -291,7 +291,7 @@ Paste these into `agents/eval/extraction_ground_truth.json` as the starting arra
         "labeler_note": "GenAI Extension Layer skill #6 → maps to ESCO 'Quality assurance'. Inferred from 'AI output validation checks and guardrails' in responsibilities."
       },
       {
-        "label": "Foundation Model Selection",
+        "skill_name": "Foundation Model Selection",
         "type": "Technical",
         "confidence": 1.0,
         "required_flag": false,
@@ -306,7 +306,7 @@ Paste these into `agents/eval/extraction_ground_truth.json` as the starting arra
         "labeler_note": "GenAI Extension Layer skill #8 → maps to ESCO 'Technology evaluation'. From 'foundation model selection for new use cases'."
       },
       {
-        "label": "Vector Database Management",
+        "skill_name": "Vector Database Management",
         "type": "Technical",
         "confidence": 1.0,
         "required_flag": true,
@@ -321,7 +321,7 @@ Paste these into `agents/eval/extraction_ground_truth.json` as the starting arra
         "labeler_note": "GenAI Extension Layer skill #9 → maps to ESCO 'Database management'."
       },
       {
-        "label": "Python",
+        "skill_name": "Python",
         "type": "Technical",
         "confidence": 1.0,
         "required_flag": true,
@@ -336,7 +336,7 @@ Paste these into `agents/eval/extraction_ground_truth.json` as the starting arra
         "labeler_note": "Ambiguous — listed as core competency, classified Technical."
       },
       {
-        "label": "ML Ops",
+        "skill_name": "ML Ops",
         "type": "Domain",
         "confidence": 1.0,
         "required_flag": true,
@@ -351,7 +351,7 @@ Paste these into `agents/eval/extraction_ground_truth.json` as the starting arra
         "labeler_note": "Compound domain skill — may resolve via embedding similarity (step 4) or fall to step 6."
       },
       {
-        "label": "Containerization",
+        "skill_name": "Containerization",
         "type": "Technical",
         "confidence": 1.0,
         "required_flag": true,
@@ -476,7 +476,7 @@ Paste these into `agents/eval/extraction_ground_truth.json` as the starting arra
     "responsibilities": "Gather and document business requirements through stakeholder interviews. Create detailed functional specifications and user stories in Jira. Build Excel-based dashboards and reports for executive leadership. Write SQL queries to extract data for ad-hoc analysis. Lead weekly cross-functional status meetings. Maintain requirements traceability matrix.",
     "skills": [
       {
-        "label": "Requirements Gathering",
+        "skill_name": "Requirements Gathering",
         "type": "Domain",
         "confidence": 1.0,
         "required_flag": true,
@@ -491,7 +491,7 @@ Paste these into `agents/eval/extraction_ground_truth.json` as the starting arra
         "labeler_note": null
       },
       {
-        "label": "SQL",
+        "skill_name": "SQL",
         "type": "Technical",
         "confidence": 1.0,
         "required_flag": true,
@@ -506,7 +506,7 @@ Paste these into `agents/eval/extraction_ground_truth.json` as the starting arra
         "labeler_note": null
       },
       {
-        "label": "Excel",
+        "skill_name": "Excel",
         "type": "Tool",
         "confidence": 1.0,
         "required_flag": true,
@@ -521,7 +521,7 @@ Paste these into `agents/eval/extraction_ground_truth.json` as the starting arra
         "labeler_note": "Ambiguous — classified as Tool (specific product). Heavy usage here: pivot tables, VLOOKUP, macros, dashboards."
       },
       {
-        "label": "Leadership",
+        "skill_name": "Leadership",
         "type": "Soft",
         "confidence": 1.0,
         "required_flag": false,
@@ -536,7 +536,7 @@ Paste these into `agents/eval/extraction_ground_truth.json` as the starting arra
         "labeler_note": "Ambiguous — inferred from 'Lead weekly cross-functional status meetings'. Not an explicit requirement."
       },
       {
-        "label": "Communication",
+        "skill_name": "Communication",
         "type": "Soft",
         "confidence": 1.0,
         "required_flag": true,
@@ -551,7 +551,7 @@ Paste these into `agents/eval/extraction_ground_truth.json` as the starting arra
         "labeler_note": "Explicitly listed: 'Strong written and verbal communication skills'."
       },
       {
-        "label": "Python",
+        "skill_name": "Python",
         "type": "Technical",
         "confidence": 1.0,
         "required_flag": false,
@@ -566,7 +566,7 @@ Paste these into `agents/eval/extraction_ground_truth.json` as the starting arra
         "labeler_note": "Ambiguous — 'Python scripting a plus but not required'. Clearly optional (required_flag=false)."
       },
       {
-        "label": "Process Modeling",
+        "skill_name": "Process Modeling",
         "type": "Domain",
         "confidence": 1.0,
         "required_flag": true,
@@ -645,7 +645,7 @@ Paste these into `agents/eval/extraction_ground_truth.json` as the starting arra
     ],
     "certifications": [
       {
-        "label": "PMP",
+        "skill_name": "PMP",
         "required_flag": false
       },
       {
@@ -665,7 +665,7 @@ Paste these into `agents/eval/extraction_ground_truth.json` as the starting arra
     "responsibilities": "Design and maintain CI/CD pipelines using Jenkins and GitLab CI. Automate infrastructure provisioning with Terraform across AWS environments. Manage Kubernetes clusters for microservice deployments. Implement monitoring dashboards using Prometheus and Grafana. Respond to production incidents and conduct post-mortems. Mentor team members on DevOps best practices and tooling.",
     "skills": [
       {
-        "label": "Linux Administration",
+        "skill_name": "Linux Administration",
         "type": "Technical",
         "confidence": 1.0,
         "required_flag": true,
@@ -680,7 +680,7 @@ Paste these into `agents/eval/extraction_ground_truth.json` as the starting arra
         "labeler_note": null
       },
       {
-        "label": "Python",
+        "skill_name": "Python",
         "type": "Technical",
         "confidence": 1.0,
         "required_flag": true,
@@ -695,7 +695,7 @@ Paste these into `agents/eval/extraction_ground_truth.json` as the starting arra
         "labeler_note": "Ambiguous — listed alongside Bash as 'scripting' tools. Classified Technical because it's a core competency here."
       },
       {
-        "label": "Infrastructure as Code",
+        "skill_name": "Infrastructure as Code",
         "type": "Domain",
         "confidence": 1.0,
         "required_flag": true,
@@ -710,7 +710,7 @@ Paste these into `agents/eval/extraction_ground_truth.json` as the starting arra
         "labeler_note": "Domain practice, not a specific tool. Terraform is the tool."
       },
       {
-        "label": "CI/CD",
+        "skill_name": "CI/CD",
         "type": "Domain",
         "confidence": 1.0,
         "required_flag": true,
@@ -725,7 +725,7 @@ Paste these into `agents/eval/extraction_ground_truth.json` as the starting arra
         "labeler_note": "Domain practice — Jenkins/GitLab CI are the tools."
       },
       {
-        "label": "Incident Response",
+        "skill_name": "Incident Response",
         "type": "Domain",
         "confidence": 1.0,
         "required_flag": true,
@@ -740,7 +740,7 @@ Paste these into `agents/eval/extraction_ground_truth.json` as the starting arra
         "labeler_note": "From 'Respond to production incidents and conduct post-mortems'."
       },
       {
-        "label": "Mentoring",
+        "skill_name": "Mentoring",
         "type": "Soft",
         "confidence": 1.0,
         "required_flag": false,
@@ -755,7 +755,7 @@ Paste these into `agents/eval/extraction_ground_truth.json` as the starting arra
         "labeler_note": "From 'Mentor team members'. Soft skill, not explicit requirement."
       },
       {
-        "label": "Leadership",
+        "skill_name": "Leadership",
         "type": "Soft",
         "confidence": 1.0,
         "required_flag": false,
@@ -880,7 +880,7 @@ Paste these into `agents/eval/extraction_ground_truth.json` as the starting arra
     "responsibilities": "Lead architecture design sessions for AI-powered solutions. Evaluate and select foundation models based on cost, quality, and latency trade-offs. Design multi-agent orchestration patterns for complex workflows. Establish AI governance guardrails and validation frameworks. Present technical solutions to C-suite and senior government officials. Mentor engineering teams on AI integration best practices.",
     "skills": [
       {
-        "label": "Agentic Systems Design",
+        "skill_name": "Agentic Systems Design",
         "type": "Technical",
         "confidence": 1.0,
         "required_flag": true,
@@ -895,7 +895,7 @@ Paste these into `agents/eval/extraction_ground_truth.json` as the starting arra
         "labeler_note": "GenAI Extension Layer skill #5 → maps to ESCO 'Software architecture'. From 'agentic AI systems or multi-agent orchestration'."
       },
       {
-        "label": "Foundation Model Selection",
+        "skill_name": "Foundation Model Selection",
         "type": "Technical",
         "confidence": 1.0,
         "required_flag": true,
@@ -910,7 +910,7 @@ Paste these into `agents/eval/extraction_ground_truth.json` as the starting arra
         "labeler_note": "GenAI Extension Layer skill #8 → maps to ESCO 'Technology evaluation'."
       },
       {
-        "label": "AI Governance",
+        "skill_name": "AI Governance",
         "type": "Domain",
         "confidence": 1.0,
         "required_flag": true,
@@ -925,7 +925,7 @@ Paste these into `agents/eval/extraction_ground_truth.json` as the starting arra
         "labeler_note": "GenAI Extension Layer skill #4 → maps to ESCO 'Digital ethics'."
       },
       {
-        "label": "AI Output Validation",
+        "skill_name": "AI Output Validation",
         "type": "Technical",
         "confidence": 1.0,
         "required_flag": false,
@@ -940,7 +940,7 @@ Paste these into `agents/eval/extraction_ground_truth.json` as the starting arra
         "labeler_note": "GenAI Extension Layer skill #6. Inferred from 'validation frameworks' in responsibilities."
       },
       {
-        "label": "Software Architecture",
+        "skill_name": "Software Architecture",
         "type": "Domain",
         "confidence": 1.0,
         "required_flag": true,
@@ -955,7 +955,7 @@ Paste these into `agents/eval/extraction_ground_truth.json` as the starting arra
         "labeler_note": "Broader than agentic systems — 7+ years of general architecture experience required."
       },
       {
-        "label": "Python",
+        "skill_name": "Python",
         "type": "Technical",
         "confidence": 1.0,
         "required_flag": true,
@@ -970,7 +970,7 @@ Paste these into `agents/eval/extraction_ground_truth.json` as the starting arra
         "labeler_note": "Ambiguous — classified Technical."
       },
       {
-        "label": "Communication",
+        "skill_name": "Communication",
         "type": "Soft",
         "confidence": 1.0,
         "required_flag": true,
@@ -985,7 +985,7 @@ Paste these into `agents/eval/extraction_ground_truth.json` as the starting arra
         "labeler_note": "From 'communicate complex AI concepts to senior government stakeholders' and 'presentation skills'."
       },
       {
-        "label": "Leadership",
+        "skill_name": "Leadership",
         "type": "Soft",
         "confidence": 1.0,
         "required_flag": true,

--- a/tools/ground-truth-labeler/ground-truth-examples.md
+++ b/tools/ground-truth-labeler/ground-truth-examples.md
@@ -1083,6 +1083,6 @@ Each team member should label 2–3 postings to collectively reach the 20–30 r
 2. **Use the ground truth labeling tool** (`tools/ground-truth-labeler`) to search JSearch and label postings.
 3. **Label 2–3 postings each** to reach the 20–30 target collectively.
 4. **Maintain the ratios:** ~30–40% GenAI roles, at least 5–8 traditional, ambiguous items throughout.
-5. **Save to:** `agents/eval/extraction_ground_truth.json`
+5. **Drop your `ground_truth_labeled.json` file in the dedicated Discord channel** — the file is gitignored to avoid merge conflicts. We'll combine all submissions into `agents/eval/extraction_ground_truth.json`.
 6. **Replace placeholder ESCO URIs** once `esco_digital_skills.json` is populated and the taxonomy store is loaded.
 7. **Add `labeler_note`** on every ambiguous call — the eval harness ignores this field but reviewers need it.

--- a/tools/ground-truth-labeler/ground-truth-examples.md
+++ b/tools/ground-truth-labeler/ground-truth-examples.md
@@ -1,0 +1,1086 @@
+# Ground Truth Labeling Examples — Week 4 Eval Harness
+
+> **Purpose:** 5 hand-labeled examples for Angel + Fabian (Pair A) to use as a template when building the full 20–30 record dataset at `agents/eval/extraction_ground_truth.json`.
+>
+> **Format decision:** JSON file, not Postgres. The eval harness loads ground truth from a fixture file and compares it against extraction output. The `extracted_intelligence` table stores agent output — ground truth stays in a separate JSON file so it's version-controlled and human-reviewable.
+
+---
+
+## Dataset Composition (5 of 20–30 target)
+
+| # | Role | GenAI Skills? | Traditional? | Ambiguous Items |
+|---|------|:------------:|:------------:|-----------------|
+| 1 | Senior Data Engineer | No | Yes | Python, SQL, Excel |
+| 2 | ML/GenAI Platform Engineer | Yes | No | Python, Kubernetes |
+| 3 | Business Analyst | No | Yes | Excel, leadership, Python |
+| 4 | DevOps Engineer | No | Yes | Python, leadership |
+| 5 | AI Solutions Architect | Yes | No | Python, leadership |
+
+**Checks:**
+- GenAI roles: 2/5 (40%) — within ~30–40% target
+- Traditional roles (no AI/ML): 3/5 — on track for 5–8 in full dataset
+- Ambiguous items: Excel (3×), leadership (3×), Python (5×) — covered
+
+---
+
+## JSON Records
+
+Paste these into `agents/eval/extraction_ground_truth.json` as the starting array:
+
+```json
+[
+  {
+    "ground_truth_id": "gt-001",
+    "title": "Senior Data Engineer",
+    "company": "Raytheon Technologies",
+    "city": "El Paso",
+    "state": "Texas",
+    "description": "We are seeking a Senior Data Engineer to design and maintain scalable data pipelines. You will work with cross-functional teams to build ETL processes, optimize SQL queries, and ensure data quality across our analytics platform. The ideal candidate has experience with cloud data warehouses, strong Python skills, and can communicate technical concepts to non-technical stakeholders.",
+    "requirements": "5+ years of data engineering experience. Proficiency in Python and SQL. Experience with Apache Spark or Databricks. Familiarity with AWS services (S3, Redshift, Glue). Strong understanding of data modeling and warehousing concepts. Experience with CI/CD pipelines. Advanced Excel skills for ad-hoc analysis. Bachelor's degree in Computer Science or related field.",
+    "responsibilities": "Design and implement scalable data pipelines using Python and Apache Spark. Optimize SQL queries and database performance. Collaborate with data scientists and analysts to deliver clean datasets. Maintain documentation for data architecture decisions. Mentor junior engineers on best practices.",
+    "skills": [
+      {
+        "label": "Python",
+        "type": "Technical",
+        "confidence": 1.0,
+        "required_flag": true,
+        "esco_uri": "http://data.europa.eu/esco/skill/bab65147-22f1-4493-86e3-4e8e8464e954",
+        "is_genai_extension": false,
+        "source_span": {
+          "text": "Python",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 6
+        },
+        "labeler_note": "Ambiguous — could be Tool. Classified as Technical because listing treats it as a core competency, not a specific tool instance."
+      },
+      {
+        "label": "SQL",
+        "type": "Technical",
+        "confidence": 1.0,
+        "required_flag": true,
+        "esco_uri": "http://data.europa.eu/esco/skill/c2e3a25b-5c53-4519-a8a6-e67b72599748",
+        "is_genai_extension": false,
+        "source_span": {
+          "text": "SQL",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 3
+        },
+        "labeler_note": null
+      },
+      {
+        "label": "Data Modeling",
+        "type": "Domain",
+        "confidence": 1.0,
+        "required_flag": true,
+        "esco_uri": null,
+        "is_genai_extension": false,
+        "source_span": {
+          "text": "Data Modeling",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 13
+        },
+        "labeler_note": "No direct ESCO match — expect step 6 (raw_skill). Enrichment phase may resolve."
+      },
+      {
+        "label": "Data Warehousing",
+        "type": "Domain",
+        "confidence": 1.0,
+        "required_flag": true,
+        "esco_uri": null,
+        "is_genai_extension": false,
+        "source_span": {
+          "text": "Data Warehousing",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 16
+        },
+        "labeler_note": null
+      },
+      {
+        "label": "ETL",
+        "type": "Technical",
+        "confidence": 1.0,
+        "required_flag": true,
+        "esco_uri": null,
+        "is_genai_extension": false,
+        "source_span": {
+          "text": "ETL",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 3
+        },
+        "labeler_note": "Acronym — agent should expand or match as-is."
+      },
+      {
+        "label": "Communication",
+        "type": "Soft",
+        "confidence": 1.0,
+        "required_flag": false,
+        "esco_uri": null,
+        "is_genai_extension": false,
+        "source_span": {
+          "text": "Communication",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 13
+        },
+        "labeler_note": "Inferred from 'communicate technical concepts to non-technical stakeholders'. Not listed as a requirement."
+      },
+      {
+        "label": "Mentoring",
+        "type": "Soft",
+        "confidence": 1.0,
+        "required_flag": false,
+        "esco_uri": null,
+        "is_genai_extension": false,
+        "source_span": {
+          "text": "Mentoring",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 9
+        },
+        "labeler_note": "From 'Mentor junior engineers'. Soft skill, not explicit requirement."
+      },
+      {
+        "label": "Excel",
+        "type": "Tool",
+        "confidence": 1.0,
+        "required_flag": true,
+        "esco_uri": null,
+        "is_genai_extension": false,
+        "source_span": {
+          "text": "Excel",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 5
+        },
+        "labeler_note": "Ambiguous — some classify as Technical. Classified as Tool because it's a specific software product (Microsoft Excel)."
+      }
+    ],
+    "tools": [
+      {
+        "tool_name": "Apache Spark",
+        "category": "framework",
+        "confidence": 1.0,
+        "source_span": {
+          "text": "Apache Spark",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 12
+        },
+        "is_genai_tool": false
+      },
+      {
+        "tool_name": "Databricks",
+        "category": "platform",
+        "confidence": 1.0,
+        "source_span": {
+          "text": "Databricks",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 10
+        },
+        "is_genai_tool": false
+      },
+      {
+        "tool_name": "AWS S3",
+        "category": "platform",
+        "confidence": 1.0,
+        "source_span": {
+          "text": "AWS S3",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 6
+        },
+        "is_genai_tool": false
+      },
+      {
+        "tool_name": "AWS Redshift",
+        "category": "database",
+        "confidence": 1.0,
+        "source_span": {
+          "text": "AWS Redshift",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 12
+        },
+        "is_genai_tool": false
+      },
+      {
+        "tool_name": "AWS Glue",
+        "category": "platform",
+        "confidence": 1.0,
+        "source_span": {
+          "text": "AWS Glue",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 8
+        },
+        "is_genai_tool": false
+      },
+      {
+        "tool_name": "Excel",
+        "category": "other",
+        "confidence": 1.0,
+        "source_span": {
+          "text": "Excel",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 5
+        },
+        "is_genai_tool": false
+      }
+    ]
+  },
+  {
+    "ground_truth_id": "gt-002",
+    "title": "ML/GenAI Platform Engineer",
+    "company": "Booz Allen Hamilton",
+    "city": "El Paso",
+    "state": "Texas",
+    "description": "Join our AI Center of Excellence to build and maintain the infrastructure powering generative AI applications for federal clients. You will design retrieval-augmented generation (RAG) pipelines, manage vector databases, and ensure prompt engineering best practices across teams. This role bridges ML ops with the emerging GenAI stack.",
+    "requirements": "3+ years experience in ML engineering or ML ops. Hands-on experience with LLM APIs (OpenAI, Anthropic, or Azure OpenAI). Proficiency in Python. Experience with vector databases (Pinecone, Weaviate, or pgvector). Understanding of RAG architectures and prompt engineering patterns. Kubernetes and Docker for model serving. Active Secret clearance or ability to obtain.",
+    "responsibilities": "Build and maintain RAG pipelines for document Q&A systems. Manage Pinecone vector database clusters and embedding pipelines. Develop prompt templates and evaluate LLM output quality. Containerize and deploy ML models using Docker and Kubernetes. Implement AI output validation checks and guardrails. Collaborate with data scientists on foundation model selection for new use cases.",
+    "skills": [
+      {
+        "label": "Prompt Engineering",
+        "type": "Technical",
+        "confidence": 1.0,
+        "required_flag": true,
+        "esco_uri": "http://data.europa.eu/esco/skill/11111111-digital-content-creation",
+        "is_genai_extension": true,
+        "source_span": {
+          "text": "Prompt Engineering",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 18
+        },
+        "labeler_note": "GenAI Extension Layer skill #1 → maps to ESCO 'Digital content creation' parent cluster."
+      },
+      {
+        "label": "RAG (Retrieval-Augmented Generation)",
+        "type": "Technical",
+        "confidence": 1.0,
+        "required_flag": true,
+        "esco_uri": "http://data.europa.eu/esco/skill/22222222-information-retrieval",
+        "is_genai_extension": true,
+        "source_span": {
+          "text": "RAG (Retrieval-Augmented Generation)",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 36
+        },
+        "labeler_note": "GenAI Extension Layer skill #2 → maps to ESCO 'Information retrieval' parent cluster."
+      },
+      {
+        "label": "AI Output Validation",
+        "type": "Technical",
+        "confidence": 1.0,
+        "required_flag": false,
+        "esco_uri": "http://data.europa.eu/esco/skill/66666666-quality-assurance",
+        "is_genai_extension": true,
+        "source_span": {
+          "text": "AI Output Validation",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 20
+        },
+        "labeler_note": "GenAI Extension Layer skill #6 → maps to ESCO 'Quality assurance'. Inferred from 'AI output validation checks and guardrails' in responsibilities."
+      },
+      {
+        "label": "Foundation Model Selection",
+        "type": "Technical",
+        "confidence": 1.0,
+        "required_flag": false,
+        "esco_uri": "http://data.europa.eu/esco/skill/88888888-technology-evaluation",
+        "is_genai_extension": true,
+        "source_span": {
+          "text": "Foundation Model Selection",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 26
+        },
+        "labeler_note": "GenAI Extension Layer skill #8 → maps to ESCO 'Technology evaluation'. From 'foundation model selection for new use cases'."
+      },
+      {
+        "label": "Vector Database Management",
+        "type": "Technical",
+        "confidence": 1.0,
+        "required_flag": true,
+        "esco_uri": "http://data.europa.eu/esco/skill/99999999-database-management",
+        "is_genai_extension": true,
+        "source_span": {
+          "text": "Vector Database Management",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 26
+        },
+        "labeler_note": "GenAI Extension Layer skill #9 → maps to ESCO 'Database management'."
+      },
+      {
+        "label": "Python",
+        "type": "Technical",
+        "confidence": 1.0,
+        "required_flag": true,
+        "esco_uri": "http://data.europa.eu/esco/skill/bab65147-22f1-4493-86e3-4e8e8464e954",
+        "is_genai_extension": false,
+        "source_span": {
+          "text": "Python",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 6
+        },
+        "labeler_note": "Ambiguous — listed as core competency, classified Technical."
+      },
+      {
+        "label": "ML Ops",
+        "type": "Domain",
+        "confidence": 1.0,
+        "required_flag": true,
+        "esco_uri": null,
+        "is_genai_extension": false,
+        "source_span": {
+          "text": "ML Ops",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 6
+        },
+        "labeler_note": "Compound domain skill — may resolve via embedding similarity (step 4) or fall to step 6."
+      },
+      {
+        "label": "Containerization",
+        "type": "Technical",
+        "confidence": 1.0,
+        "required_flag": true,
+        "esco_uri": null,
+        "is_genai_extension": false,
+        "source_span": {
+          "text": "Containerization",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 16
+        },
+        "labeler_note": "Inferred from Docker/Kubernetes requirement. Agent may extract 'Docker' as Tool and miss this as a skill."
+      }
+    ],
+    "tools": [
+      {
+        "tool_name": "Docker",
+        "category": "devops",
+        "confidence": 1.0,
+        "source_span": {
+          "text": "Docker",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 6
+        },
+        "is_genai_tool": false
+      },
+      {
+        "tool_name": "Kubernetes",
+        "category": "devops",
+        "confidence": 1.0,
+        "source_span": {
+          "text": "Kubernetes",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 10
+        },
+        "is_genai_tool": false
+      },
+      {
+        "tool_name": "Pinecone",
+        "category": "database",
+        "confidence": 1.0,
+        "source_span": {
+          "text": "Pinecone",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 8
+        },
+        "is_genai_tool": true
+      },
+      {
+        "tool_name": "Weaviate",
+        "category": "database",
+        "confidence": 1.0,
+        "source_span": {
+          "text": "Weaviate",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 8
+        },
+        "is_genai_tool": true
+      },
+      {
+        "tool_name": "pgvector",
+        "category": "database",
+        "confidence": 1.0,
+        "source_span": {
+          "text": "pgvector",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 8
+        },
+        "is_genai_tool": true
+      },
+      {
+        "tool_name": "OpenAI API",
+        "category": "ai_tool",
+        "confidence": 1.0,
+        "source_span": {
+          "text": "OpenAI API",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 10
+        },
+        "is_genai_tool": true
+      },
+      {
+        "tool_name": "Anthropic API",
+        "category": "ai_tool",
+        "confidence": 1.0,
+        "source_span": {
+          "text": "Anthropic API",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 13
+        },
+        "is_genai_tool": true
+      },
+      {
+        "tool_name": "Azure OpenAI",
+        "category": "ai_tool",
+        "confidence": 1.0,
+        "source_span": {
+          "text": "Azure OpenAI",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 12
+        },
+        "is_genai_tool": true
+      }
+    ]
+  },
+  {
+    "ground_truth_id": "gt-003",
+    "title": "Business Analyst",
+    "company": "El Paso Electric",
+    "city": "El Paso",
+    "state": "Texas",
+    "description": "El Paso Electric is seeking a Business Analyst to support our IT modernization initiative. You will gather requirements from business stakeholders, translate them into technical specifications, and work with development teams to deliver solutions. Strong analytical thinking, Excel proficiency, and the ability to lead cross-functional meetings are essential.",
+    "requirements": "3+ years as a Business Analyst or similar role. Advanced Excel skills including pivot tables, VLOOKUP, and macros. Experience with SQL for data extraction and reporting. Familiarity with Jira or Azure DevOps for project tracking. Strong written and verbal communication skills. Experience creating process flow diagrams using Visio or Lucidchart. Python scripting a plus but not required. PMP or CBAP certification preferred.",
+    "responsibilities": "Gather and document business requirements through stakeholder interviews. Create detailed functional specifications and user stories in Jira. Build Excel-based dashboards and reports for executive leadership. Write SQL queries to extract data for ad-hoc analysis. Lead weekly cross-functional status meetings. Maintain requirements traceability matrix.",
+    "skills": [
+      {
+        "label": "Requirements Gathering",
+        "type": "Domain",
+        "confidence": 1.0,
+        "required_flag": true,
+        "esco_uri": null,
+        "is_genai_extension": false,
+        "source_span": {
+          "text": "Requirements Gathering",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 22
+        },
+        "labeler_note": null
+      },
+      {
+        "label": "SQL",
+        "type": "Technical",
+        "confidence": 1.0,
+        "required_flag": true,
+        "esco_uri": "http://data.europa.eu/esco/skill/c2e3a25b-5c53-4519-a8a6-e67b72599748",
+        "is_genai_extension": false,
+        "source_span": {
+          "text": "SQL",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 3
+        },
+        "labeler_note": null
+      },
+      {
+        "label": "Excel",
+        "type": "Tool",
+        "confidence": 1.0,
+        "required_flag": true,
+        "esco_uri": null,
+        "is_genai_extension": false,
+        "source_span": {
+          "text": "Excel",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 5
+        },
+        "labeler_note": "Ambiguous — classified as Tool (specific product). Heavy usage here: pivot tables, VLOOKUP, macros, dashboards."
+      },
+      {
+        "label": "Leadership",
+        "type": "Soft",
+        "confidence": 1.0,
+        "required_flag": false,
+        "esco_uri": null,
+        "is_genai_extension": false,
+        "source_span": {
+          "text": "Leadership",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 10
+        },
+        "labeler_note": "Ambiguous — inferred from 'Lead weekly cross-functional status meetings'. Not an explicit requirement."
+      },
+      {
+        "label": "Communication",
+        "type": "Soft",
+        "confidence": 1.0,
+        "required_flag": true,
+        "esco_uri": null,
+        "is_genai_extension": false,
+        "source_span": {
+          "text": "Communication",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 13
+        },
+        "labeler_note": "Explicitly listed: 'Strong written and verbal communication skills'."
+      },
+      {
+        "label": "Python",
+        "type": "Technical",
+        "confidence": 1.0,
+        "required_flag": false,
+        "esco_uri": "http://data.europa.eu/esco/skill/bab65147-22f1-4493-86e3-4e8e8464e954",
+        "is_genai_extension": false,
+        "source_span": {
+          "text": "Python",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 6
+        },
+        "labeler_note": "Ambiguous — 'Python scripting a plus but not required'. Clearly optional (required_flag=false)."
+      },
+      {
+        "label": "Process Modeling",
+        "type": "Domain",
+        "confidence": 1.0,
+        "required_flag": true,
+        "esco_uri": null,
+        "is_genai_extension": false,
+        "source_span": {
+          "text": "Process Modeling",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 16
+        },
+        "labeler_note": "Inferred from 'process flow diagrams'. Agent may extract as 'Business Process Modeling' — both acceptable."
+      }
+    ],
+    "tools": [
+      {
+        "tool_name": "Excel",
+        "category": "other",
+        "confidence": 1.0,
+        "source_span": {
+          "text": "Excel",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 5
+        },
+        "is_genai_tool": false
+      },
+      {
+        "tool_name": "Jira",
+        "category": "platform",
+        "confidence": 1.0,
+        "source_span": {
+          "text": "Jira",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 4
+        },
+        "is_genai_tool": false
+      },
+      {
+        "tool_name": "Azure DevOps",
+        "category": "platform",
+        "confidence": 1.0,
+        "source_span": {
+          "text": "Azure DevOps",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 12
+        },
+        "is_genai_tool": false
+      },
+      {
+        "tool_name": "Visio",
+        "category": "other",
+        "confidence": 1.0,
+        "source_span": {
+          "text": "Visio",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 5
+        },
+        "is_genai_tool": false
+      },
+      {
+        "tool_name": "Lucidchart",
+        "category": "other",
+        "confidence": 1.0,
+        "source_span": {
+          "text": "Lucidchart",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 10
+        },
+        "is_genai_tool": false
+      }
+    ],
+    "certifications": [
+      {
+        "label": "PMP",
+        "required_flag": false
+      },
+      {
+        "label": "CBAP",
+        "required_flag": false
+      }
+    ]
+  },
+  {
+    "ground_truth_id": "gt-004",
+    "title": "DevOps Engineer",
+    "company": "SAIC",
+    "city": "El Paso",
+    "state": "Texas",
+    "description": "SAIC is hiring a DevOps Engineer to support infrastructure automation for defense programs at Fort Bliss. You will build and maintain CI/CD pipelines, manage cloud infrastructure using Infrastructure as Code, and ensure system reliability through monitoring and incident response. This is a hands-on role requiring strong Linux administration and scripting skills.",
+    "requirements": "4+ years of DevOps or SRE experience. Strong Linux systems administration. Proficiency in Python or Bash scripting for automation. Experience with Terraform or CloudFormation for IaC. Hands-on experience with Jenkins or GitLab CI/CD. Container orchestration with Kubernetes and Docker. Monitoring and alerting with Prometheus and Grafana. AWS or Azure cloud certifications preferred. Active Secret clearance required.",
+    "responsibilities": "Design and maintain CI/CD pipelines using Jenkins and GitLab CI. Automate infrastructure provisioning with Terraform across AWS environments. Manage Kubernetes clusters for microservice deployments. Implement monitoring dashboards using Prometheus and Grafana. Respond to production incidents and conduct post-mortems. Mentor team members on DevOps best practices and tooling.",
+    "skills": [
+      {
+        "label": "Linux Administration",
+        "type": "Technical",
+        "confidence": 1.0,
+        "required_flag": true,
+        "esco_uri": null,
+        "is_genai_extension": false,
+        "source_span": {
+          "text": "Linux Administration",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 20
+        },
+        "labeler_note": null
+      },
+      {
+        "label": "Python",
+        "type": "Technical",
+        "confidence": 1.0,
+        "required_flag": true,
+        "esco_uri": "http://data.europa.eu/esco/skill/bab65147-22f1-4493-86e3-4e8e8464e954",
+        "is_genai_extension": false,
+        "source_span": {
+          "text": "Python",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 6
+        },
+        "labeler_note": "Ambiguous — listed alongside Bash as 'scripting' tools. Classified Technical because it's a core competency here."
+      },
+      {
+        "label": "Infrastructure as Code",
+        "type": "Domain",
+        "confidence": 1.0,
+        "required_flag": true,
+        "esco_uri": null,
+        "is_genai_extension": false,
+        "source_span": {
+          "text": "Infrastructure as Code",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 22
+        },
+        "labeler_note": "Domain practice, not a specific tool. Terraform is the tool."
+      },
+      {
+        "label": "CI/CD",
+        "type": "Domain",
+        "confidence": 1.0,
+        "required_flag": true,
+        "esco_uri": null,
+        "is_genai_extension": false,
+        "source_span": {
+          "text": "CI/CD",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 5
+        },
+        "labeler_note": "Domain practice — Jenkins/GitLab CI are the tools."
+      },
+      {
+        "label": "Incident Response",
+        "type": "Domain",
+        "confidence": 1.0,
+        "required_flag": true,
+        "esco_uri": null,
+        "is_genai_extension": false,
+        "source_span": {
+          "text": "Incident Response",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 17
+        },
+        "labeler_note": "From 'Respond to production incidents and conduct post-mortems'."
+      },
+      {
+        "label": "Mentoring",
+        "type": "Soft",
+        "confidence": 1.0,
+        "required_flag": false,
+        "esco_uri": null,
+        "is_genai_extension": false,
+        "source_span": {
+          "text": "Mentoring",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 9
+        },
+        "labeler_note": "From 'Mentor team members'. Soft skill, not explicit requirement."
+      },
+      {
+        "label": "Leadership",
+        "type": "Soft",
+        "confidence": 1.0,
+        "required_flag": false,
+        "esco_uri": null,
+        "is_genai_extension": false,
+        "source_span": {
+          "text": "Leadership",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 10
+        },
+        "labeler_note": "Ambiguous — inferred from mentoring responsibility. Debatable whether this counts separately from Mentoring."
+      }
+    ],
+    "tools": [
+      {
+        "tool_name": "Jenkins",
+        "category": "devops",
+        "confidence": 1.0,
+        "source_span": {
+          "text": "Jenkins",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 7
+        },
+        "is_genai_tool": false
+      },
+      {
+        "tool_name": "GitLab CI",
+        "category": "devops",
+        "confidence": 1.0,
+        "source_span": {
+          "text": "GitLab CI",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 9
+        },
+        "is_genai_tool": false
+      },
+      {
+        "tool_name": "Terraform",
+        "category": "devops",
+        "confidence": 1.0,
+        "source_span": {
+          "text": "Terraform",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 9
+        },
+        "is_genai_tool": false
+      },
+      {
+        "tool_name": "CloudFormation",
+        "category": "devops",
+        "confidence": 1.0,
+        "source_span": {
+          "text": "CloudFormation",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 14
+        },
+        "is_genai_tool": false
+      },
+      {
+        "tool_name": "Kubernetes",
+        "category": "devops",
+        "confidence": 1.0,
+        "source_span": {
+          "text": "Kubernetes",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 10
+        },
+        "is_genai_tool": false
+      },
+      {
+        "tool_name": "Docker",
+        "category": "devops",
+        "confidence": 1.0,
+        "source_span": {
+          "text": "Docker",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 6
+        },
+        "is_genai_tool": false
+      },
+      {
+        "tool_name": "Prometheus",
+        "category": "devops",
+        "confidence": 1.0,
+        "source_span": {
+          "text": "Prometheus",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 10
+        },
+        "is_genai_tool": false
+      },
+      {
+        "tool_name": "Grafana",
+        "category": "devops",
+        "confidence": 1.0,
+        "source_span": {
+          "text": "Grafana",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 7
+        },
+        "is_genai_tool": false
+      }
+    ]
+  },
+  {
+    "ground_truth_id": "gt-005",
+    "title": "AI Solutions Architect",
+    "company": "Accenture Federal Services",
+    "city": "El Paso",
+    "state": "Texas",
+    "description": "We are looking for an AI Solutions Architect to lead the design of intelligent automation solutions for federal agencies. You will evaluate foundation models, design agentic systems that orchestrate multiple AI capabilities, and ensure AI governance standards are met. This role requires both deep technical expertise and the ability to communicate complex AI concepts to senior government stakeholders.",
+    "requirements": "7+ years in software architecture, with 2+ years focused on AI/ML systems. Experience designing agentic AI systems or multi-agent orchestration pipelines. Hands-on experience with LLM APIs and embedding models. Understanding of AI governance frameworks and responsible AI principles. Proficiency in Python. Experience with Azure AI services. Strong presentation and leadership skills. TOGAF or AWS Solutions Architect certification preferred.",
+    "responsibilities": "Lead architecture design sessions for AI-powered solutions. Evaluate and select foundation models based on cost, quality, and latency trade-offs. Design multi-agent orchestration patterns for complex workflows. Establish AI governance guardrails and validation frameworks. Present technical solutions to C-suite and senior government officials. Mentor engineering teams on AI integration best practices.",
+    "skills": [
+      {
+        "label": "Agentic Systems Design",
+        "type": "Technical",
+        "confidence": 1.0,
+        "required_flag": true,
+        "esco_uri": "http://data.europa.eu/esco/skill/55555555-software-architecture",
+        "is_genai_extension": true,
+        "source_span": {
+          "text": "Agentic Systems Design",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 22
+        },
+        "labeler_note": "GenAI Extension Layer skill #5 → maps to ESCO 'Software architecture'. From 'agentic AI systems or multi-agent orchestration'."
+      },
+      {
+        "label": "Foundation Model Selection",
+        "type": "Technical",
+        "confidence": 1.0,
+        "required_flag": true,
+        "esco_uri": "http://data.europa.eu/esco/skill/88888888-technology-evaluation",
+        "is_genai_extension": true,
+        "source_span": {
+          "text": "Foundation Model Selection",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 26
+        },
+        "labeler_note": "GenAI Extension Layer skill #8 → maps to ESCO 'Technology evaluation'."
+      },
+      {
+        "label": "AI Governance",
+        "type": "Domain",
+        "confidence": 1.0,
+        "required_flag": true,
+        "esco_uri": "http://data.europa.eu/esco/skill/44444444-digital-ethics",
+        "is_genai_extension": true,
+        "source_span": {
+          "text": "AI Governance",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 13
+        },
+        "labeler_note": "GenAI Extension Layer skill #4 → maps to ESCO 'Digital ethics'."
+      },
+      {
+        "label": "AI Output Validation",
+        "type": "Technical",
+        "confidence": 1.0,
+        "required_flag": false,
+        "esco_uri": "http://data.europa.eu/esco/skill/66666666-quality-assurance",
+        "is_genai_extension": true,
+        "source_span": {
+          "text": "AI Output Validation",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 20
+        },
+        "labeler_note": "GenAI Extension Layer skill #6. Inferred from 'validation frameworks' in responsibilities."
+      },
+      {
+        "label": "Software Architecture",
+        "type": "Domain",
+        "confidence": 1.0,
+        "required_flag": true,
+        "esco_uri": null,
+        "is_genai_extension": false,
+        "source_span": {
+          "text": "Software Architecture",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 21
+        },
+        "labeler_note": "Broader than agentic systems — 7+ years of general architecture experience required."
+      },
+      {
+        "label": "Python",
+        "type": "Technical",
+        "confidence": 1.0,
+        "required_flag": true,
+        "esco_uri": "http://data.europa.eu/esco/skill/bab65147-22f1-4493-86e3-4e8e8464e954",
+        "is_genai_extension": false,
+        "source_span": {
+          "text": "Python",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 6
+        },
+        "labeler_note": "Ambiguous — classified Technical."
+      },
+      {
+        "label": "Communication",
+        "type": "Soft",
+        "confidence": 1.0,
+        "required_flag": true,
+        "esco_uri": null,
+        "is_genai_extension": false,
+        "source_span": {
+          "text": "Communication",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 13
+        },
+        "labeler_note": "From 'communicate complex AI concepts to senior government stakeholders' and 'presentation skills'."
+      },
+      {
+        "label": "Leadership",
+        "type": "Soft",
+        "confidence": 1.0,
+        "required_flag": true,
+        "esco_uri": null,
+        "is_genai_extension": false,
+        "source_span": {
+          "text": "Leadership",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 10
+        },
+        "labeler_note": "Ambiguous — explicitly listed as requirement AND inferred from 'Lead architecture design sessions', 'Mentor engineering teams'."
+      }
+    ],
+    "tools": [
+      {
+        "tool_name": "Azure AI Services",
+        "category": "platform",
+        "confidence": 1.0,
+        "source_span": {
+          "text": "Azure AI Services",
+          "field_source": "requirements",
+          "start_char": 0,
+          "end_char": 17
+        },
+        "is_genai_tool": true
+      }
+    ],
+    "certifications": [
+      {
+        "label": "TOGAF",
+        "required_flag": false
+      },
+      {
+        "label": "AWS Solutions Architect",
+        "required_flag": false
+      }
+    ]
+  }
+]
+```
+
+---
+
+## Labeling Decisions Log
+
+These decisions should be consistent across all 20–30 records. Angel + Fabian (Pair A) should follow these when labeling the remaining 15–25 postings.
+
+| Item | Decision | Rationale |
+|------|----------|-----------|
+| **Python** | SkillRecord `type: "Technical"` when listed as a competency; ToolRecord `tool_name: "Python"`, `category: "language"` | It's both. Skill = competency. Tool = the runtime. |
+| **Excel** | SkillRecord `type: "Tool"`; ToolRecord `tool_name: "Excel"`, `category: "other"` | It's a specific product, not a technical practice. |
+| **Leadership** | `type: "Soft"`, `required_flag` depends on explicit mention | Only `true` if the listing explicitly says "leadership skills required". Otherwise `false` (inferred). |
+| **Communication** | `type: "Soft"` | Always Soft. Check if explicitly required or inferred from context. |
+| **GenAI Extension skills** | Use exact labels from the 10-skill list | Must match exactly: "Prompt Engineering" not "prompt design". |
+| **esco_uri for GenAI** | Use placeholder URIs until ESCO store is populated | Replace with real URIs from `esco_digital_skills.json` once available. |
+| **source_span** | Required on every record. For hand-labeled ground truth, set `start_char: 0` and `end_char: len(text)` with `text` set to the skill/tool label. `field_source` indicates which section the skill appears in. | SpanRecord validates `end_char - start_char == len(text)` and `start_char >= 0`, so sentinel values like `-1` will fail Pydantic validation. Use `text: "Python", start_char: 0, end_char: 6` pattern for ground truth. |
+| **is_genai_tool** | `true` on ToolRecord for AI/GenAI-specific tools (Pinecone, LangChain, OpenAI API, etc.) | Matches the ToolRecord schema from PR #62. |
+| **Certifications** | Separate `certifications` array | Not in the SkillRecord schema as a type — track separately for eval. |
+
+---
+
+## Sourcing Real Postings via JSearch
+
+These 5 examples use synthetic job descriptions. For the remaining 15–25 records, Angel + Fabian (Pair A) should pull **real postings** from the JSearch API to ensure the ground truth reflects actual employer language, not what we think a listing looks like.
+
+**Recommended queries** (El Paso / Borderplex region):
+
+| Query | Why |
+|-------|-----|
+| `data engineer in el paso tx` | Traditional role, likely has Python/SQL/Excel ambiguity |
+| `AI engineer in el paso tx` | GenAI skills, tests Extension Layer detection |
+| `business analyst in el paso tx` | Traditional, Excel-heavy, soft skills |
+| `devops engineer in el paso tx` | Traditional infra role, no AI/ML |
+| `machine learning engineer in el paso tx` | GenAI-adjacent, tests boundary between ML and GenAI |
+| `software developer in el paso tx` | General role, tests breadth of extraction |
+| `cybersecurity analyst in el paso tx` | Traditional, domain-heavy, tests cert extraction |
+
+**Workflow:**
+1. Query JSearch → get raw posting JSON
+2. Copy `title`, `company`, `description` fields from the API response
+3. Split description into `requirements` / `responsibilities` manually (JSearch returns a single description blob)
+4. Hand-label `skills`, `tools`, and `certifications`
+5. Add `labeler_note` on every ambiguous call
+
+This produces ground truth that the eval harness can compare against the agent's extraction of the **same real postings** already in the ingestion pipeline.
+
+---
+
+## Next Steps for Angel + Fabian (Pair A)
+
+1. **Use these 5 records as your template** — match this exact JSON structure.
+2. **Pull real postings from JSearch** using the queries above.
+3. **Label 15–25 more postings** by hand to reach the 20–30 target.
+4. **Maintain the ratios:** ~30–40% GenAI roles, at least 5–8 traditional, ambiguous items throughout.
+5. **Save to:** `agents/eval/extraction_ground_truth.json`
+6. **Replace placeholder ESCO URIs** once `esco_digital_skills.json` is populated and the taxonomy store is loaded.
+7. **Add `labeler_note`** on every ambiguous call — the eval harness ignores this field but reviewers need it.

--- a/tools/ground-truth-labeler/ground-truth-examples.md
+++ b/tools/ground-truth-labeler/ground-truth-examples.md
@@ -1,6 +1,6 @@
 # Ground Truth Labeling Examples — Week 4 Eval Harness
 
-> **Purpose:** 5 hand-labeled examples for Angel + Fabian (Pair A) to use as a template when building the full 20–30 record dataset at `agents/eval/extraction_ground_truth.json`.
+> **Purpose:** 5 hand-labeled examples for the team to use as a template when building the full 20–30 record dataset at `agents/eval/extraction_ground_truth.json`. Each pair should label 2–3 postings using the ground truth labeling tool.
 >
 > **Format decision:** JSON file, not Postgres. The eval harness loads ground truth from a fixture file and compares it against extraction output. The `extracted_intelligence` table stores agent output — ground truth stays in a separate JSON file so it's version-controlled and human-reviewable.
 
@@ -1032,7 +1032,7 @@ Paste these into `agents/eval/extraction_ground_truth.json` as the starting arra
 
 ## Labeling Decisions Log
 
-These decisions should be consistent across all 20–30 records. Angel + Fabian (Pair A) should follow these when labeling the remaining 15–25 postings.
+These decisions should be consistent across all 20–30 records. All pairs should follow these when labeling their assigned postings.
 
 | Item | Decision | Rationale |
 |------|----------|-----------|
@@ -1050,7 +1050,7 @@ These decisions should be consistent across all 20–30 records. Angel + Fabian 
 
 ## Sourcing Real Postings via JSearch
 
-These 5 examples use synthetic job descriptions. For the remaining 15–25 records, Angel + Fabian (Pair A) should pull **real postings** from the JSearch API to ensure the ground truth reflects actual employer language, not what we think a listing looks like.
+These 5 examples use synthetic job descriptions. For the remaining 15–25 records, each pair should pull **real postings** using the ground truth labeling tool (JSearch integration) to ensure the ground truth reflects actual employer language, not what we think a listing looks like.
 
 **Recommended queries** (El Paso / Borderplex region):
 
@@ -1075,11 +1075,13 @@ This produces ground truth that the eval harness can compare against the agent's
 
 ---
 
-## Next Steps for Angel + Fabian (Pair A)
+## Next Steps for All Pairs
+
+Each pair should label 2–3 postings to collectively reach the 20–30 record target.
 
 1. **Use these 5 records as your template** — match this exact JSON structure.
-2. **Pull real postings from JSearch** using the queries above.
-3. **Label 15–25 more postings** by hand to reach the 20–30 target.
+2. **Use the ground truth labeling tool** (`tools/ground-truth-labeler`) to search JSearch and label postings.
+3. **Label 2–3 postings per pair** to reach the 20–30 target collectively.
 4. **Maintain the ratios:** ~30–40% GenAI roles, at least 5–8 traditional, ambiguous items throughout.
 5. **Save to:** `agents/eval/extraction_ground_truth.json`
 6. **Replace placeholder ESCO URIs** once `esco_digital_skills.json` is populated and the taxonomy store is loaded.

--- a/tools/ground-truth-labeler/ground-truth-examples.md
+++ b/tools/ground-truth-labeler/ground-truth-examples.md
@@ -1,6 +1,6 @@
 # Ground Truth Labeling Examples — Week 4 Eval Harness
 
-> **Purpose:** 5 hand-labeled examples for the team to use as a template when building the full 20–30 record dataset at `agents/eval/extraction_ground_truth.json`. Each pair should label 2–3 postings using the ground truth labeling tool.
+> **Purpose:** 5 hand-labeled examples for the team to use as a template when building the full 20–30 record dataset at `agents/eval/extraction_ground_truth.json`. Each team member should label 2–3 postings using the ground truth labeling tool.
 >
 > **Format decision:** JSON file, not Postgres. The eval harness loads ground truth from a fixture file and compares it against extraction output. The `extracted_intelligence` table stores agent output — ground truth stays in a separate JSON file so it's version-controlled and human-reviewable.
 
@@ -1032,7 +1032,7 @@ Paste these into `agents/eval/extraction_ground_truth.json` as the starting arra
 
 ## Labeling Decisions Log
 
-These decisions should be consistent across all 20–30 records. All pairs should follow these when labeling their assigned postings.
+These decisions should be consistent across all 20–30 records. Everyone should follow these when labeling their assigned postings.
 
 | Item | Decision | Rationale |
 |------|----------|-----------|
@@ -1050,7 +1050,7 @@ These decisions should be consistent across all 20–30 records. All pairs shoul
 
 ## Sourcing Real Postings via JSearch
 
-These 5 examples use synthetic job descriptions. For the remaining 15–25 records, each pair should pull **real postings** using the ground truth labeling tool (JSearch integration) to ensure the ground truth reflects actual employer language, not what we think a listing looks like.
+These 5 examples use synthetic job descriptions. For the remaining 15–25 records, each team member should pull **real postings** using the ground truth labeling tool (JSearch integration) to ensure the ground truth reflects actual employer language, not what we think a listing looks like.
 
 **Recommended queries** (El Paso / Borderplex region):
 
@@ -1075,13 +1075,13 @@ This produces ground truth that the eval harness can compare against the agent's
 
 ---
 
-## Next Steps for All Pairs
+## Next Steps for the Team
 
-Each pair should label 2–3 postings to collectively reach the 20–30 record target.
+Each team member should label 2–3 postings to collectively reach the 20–30 record target.
 
 1. **Use these 5 records as your template** — match this exact JSON structure.
 2. **Use the ground truth labeling tool** (`tools/ground-truth-labeler`) to search JSearch and label postings.
-3. **Label 2–3 postings per pair** to reach the 20–30 target collectively.
+3. **Label 2–3 postings each** to reach the 20–30 target collectively.
 4. **Maintain the ratios:** ~30–40% GenAI roles, at least 5–8 traditional, ambiguous items throughout.
 5. **Save to:** `agents/eval/extraction_ground_truth.json`
 6. **Replace placeholder ESCO URIs** once `esco_digital_skills.json` is populated and the taxonomy store is loaded.

--- a/tools/ground-truth-labeler/jsearch_client.py
+++ b/tools/ground-truth-labeler/jsearch_client.py
@@ -1,0 +1,98 @@
+"""Lightweight JSearch API client for the ground truth labeling tool.
+
+Reuses the same JSEARCH_API_KEY env var as the ingestion agent.
+Pattern borrowed from agents/ingestion/sources/jsearch_adapter.py.
+"""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+
+JSEARCH_BASE_URL = "https://jsearch.p.rapidapi.com/search"
+JSEARCH_HOST = "jsearch.p.rapidapi.com"
+
+
+def fix_mojibake(text: str) -> str:
+    """Fix UTF-8 text that was decoded as Latin-1 (common JSearch issue).
+
+    Example: 'â€¢' → '•', 'â€"' → '—', 'â€™' → '''
+    """
+    try:
+        return text.encode("cp1252").decode("utf-8")
+    except (UnicodeEncodeError, UnicodeDecodeError):
+        return text
+
+
+def get_api_key() -> str | None:
+    """Return the JSearch API key from env, or None if unset."""
+    return os.getenv("JSEARCH_API_KEY")
+
+
+def search_jobs(query: str, num_results: int = 10) -> list[dict]:
+    """Search JSearch API and return raw job dicts.
+
+    Args:
+        query: Search string (e.g. "data engineer El Paso TX").
+        num_results: Max results to return (1-10 per page).
+
+    Returns:
+        List of raw job dicts from the JSearch API response.
+        Each dict contains: job_id, job_title, employer_name,
+        job_description, job_city, job_state, job_highlights, etc.
+    """
+    api_key = get_api_key()
+    if not api_key:
+        return []
+
+    headers = {
+        "X-RapidAPI-Key": api_key,
+        "X-RapidAPI-Host": JSEARCH_HOST,
+    }
+    params = {
+        "query": query,
+        "page": "1",
+        "num_pages": "1",
+    }
+
+    try:
+        resp = httpx.get(JSEARCH_BASE_URL, headers=headers, params=params, timeout=15)
+        resp.raise_for_status()
+        data = resp.json().get("data", [])
+        return data[:num_results]
+    except (httpx.HTTPError, KeyError, ValueError) as exc:
+        return [{"error": str(exc)}]
+
+
+def parse_job_sections(job: dict) -> dict:
+    """Extract labeled text sections from a JSearch job dict.
+
+    Returns a dict with keys: title, company, city, state, external_id,
+    description, requirements, responsibilities — ready for the labeler UI.
+    """
+    highlights = job.get("job_highlights") or {}
+
+    # Requirements: join Qualifications array if present
+    qualifications = highlights.get("Qualifications") or []
+    requirements_text = "\n".join(f"- {q}" for q in qualifications) if qualifications else ""
+
+    # Responsibilities: join Responsibilities array if present
+    responsibilities_list = highlights.get("Responsibilities") or []
+    responsibilities_text = (
+        "\n".join(f"- {r}" for r in responsibilities_list) if responsibilities_list else ""
+    )
+
+    return {
+        "external_id": job.get("job_id", ""),
+        "title": fix_mojibake(job.get("job_title") or job.get("title", "")),
+        "company": fix_mojibake(job.get("employer_name") or job.get("company_name", "")),
+        "city": job.get("job_city", ""),
+        "state": job.get("job_state", ""),
+        "description": fix_mojibake(job.get("job_description") or job.get("description", "")),
+        "requirements": fix_mojibake(requirements_text),
+        "responsibilities": fix_mojibake(responsibilities_text),
+        "job_url": job.get("job_apply_link") or job.get("job_google_link", ""),
+        "is_remote": job.get("job_is_remote", False),
+        "employment_type": job.get("job_employment_type", ""),
+    }

--- a/tools/ground-truth-labeler/requirements.txt
+++ b/tools/ground-truth-labeler/requirements.txt
@@ -1,0 +1,4 @@
+streamlit>=1.30
+httpx>=0.27
+pydantic>=2.0
+python-dotenv>=1.0

--- a/tools/ground-truth-labeler/schema.py
+++ b/tools/ground-truth-labeler/schema.py
@@ -59,7 +59,7 @@ class SkillRecord(BaseModel):
     """A single extracted skill with taxonomy linking metadata."""
 
     skill_id: str | None = None
-    label: str
+    skill_name: str
     type: SkillType
     confidence: float = Field(ge=0.0, le=1.0)
     required_flag: bool | None = None

--- a/tools/ground-truth-labeler/schema.py
+++ b/tools/ground-truth-labeler/schema.py
@@ -1,0 +1,101 @@
+"""Pydantic models for ground truth labeling.
+
+Mirrors the extraction_types.py from week-04/skills-tools-extraction branch
+(PR #64 schema — required source_span, start_char/end_char, validators).
+
+These models are used by the labeling app to validate records before export.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+# --- Literal types (match extraction_types.py) ---
+
+FieldSource = Literal["title", "description", "requirements", "responsibilities"]
+SkillType = Literal["Technical", "Domain", "Soft", "Certification", "Tool"]
+ToolCategory = Literal[
+    "language", "framework", "platform", "database", "devops", "ai_tool", "other"
+]
+
+# --- 10 GenAI Extension Skills (for labeler reference) ---
+
+GENAI_SKILLS = [
+    "Prompt Engineering",
+    "RAG (Retrieval-Augmented Generation)",
+    "Fine-Tuning",
+    "AI Governance",
+    "LLM Evaluation",
+    "Agentic Workflows",
+    "Vector Database Management",
+    "AI Safety & Alignment",
+    "Multimodal AI",
+    "AI-Assisted Code Generation",
+]
+
+
+class SpanRecord(BaseModel):
+    """Source evidence span linking an extraction back to the original text."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    text: str
+    field_source: FieldSource
+    start_char: int = Field(ge=0)
+    end_char: int = Field(ge=0)
+
+    @model_validator(mode="after")
+    def validate_offsets(self) -> SpanRecord:
+        if self.end_char < self.start_char:
+            raise ValueError("end_char must be >= start_char")
+        if (self.end_char - self.start_char) != len(self.text):
+            raise ValueError("span offsets must match the captured text length")
+        return self
+
+
+class SkillRecord(BaseModel):
+    """A single extracted skill with taxonomy linking metadata."""
+
+    skill_id: str | None = None
+    label: str
+    type: SkillType
+    confidence: float = Field(ge=0.0, le=1.0)
+    required_flag: bool | None = None
+    esco_uri: str | None = None
+    is_genai_extension: bool = False
+    source_span: SpanRecord
+    span_auto_corrected: bool = False
+    original_end_char: int | None = None
+
+
+class ToolRecord(BaseModel):
+    """A single extracted tool."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    tool_id: str | None = None
+    tool_name: str
+    category: ToolCategory
+    confidence: float = Field(ge=0.0, le=1.0)
+    source_span: SpanRecord
+    is_genai_tool: bool = False
+
+
+class GroundTruthRecord(BaseModel):
+    """A fully labeled ground truth record for one job posting."""
+
+    ground_truth_id: str
+    external_id: str = ""
+    source: str = "JSearch"
+    title: str
+    company: str
+    city: str | None = None
+    state: str | None = None
+    description: str = ""
+    requirements: str = ""
+    responsibilities: str = ""
+    skills: list[SkillRecord] = Field(default_factory=list)
+    tools: list[ToolRecord] = Field(default_factory=list)
+    labeler_notes: dict[str, str] = Field(default_factory=dict)

--- a/tools/ground-truth-labeler/text_selector.py
+++ b/tools/ground-truth-labeler/text_selector.py
@@ -163,17 +163,22 @@ def render_selectable_job_text(job: dict, bridge_key: str = "span_bridge") -> No
             }}
 
             // Find the hidden Streamlit text_input, set value, press Enter to trigger rerun
-            var input = parentDoc.querySelector('input[aria-label="span_data"]');
-            if (input) {{
-                input.focus();
-                var nativeInputValueSetter = Object.getOwnPropertyDescriptor(
-                    window.parent.HTMLInputElement.prototype, 'value'
-                ).set;
-                nativeInputValueSetter.call(input, data);
-                input.dispatchEvent(new Event('input', {{ bubbles: true }}));
-                input.dispatchEvent(new KeyboardEvent('keydown', {{ key: 'Enter', code: 'Enter', keyCode: 13, bubbles: true }}));
-                input.dispatchEvent(new KeyboardEvent('keypress', {{ key: 'Enter', code: 'Enter', keyCode: 13, bubbles: true }}));
+            function setSpanInput(data, retries) {{
+                var input = parentDoc.querySelector('input[aria-label="span_data"]');
+                if (input) {{
+                    input.focus();
+                    var nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+                        window.parent.HTMLInputElement.prototype, 'value'
+                    ).set;
+                    nativeInputValueSetter.call(input, data);
+                    input.dispatchEvent(new Event('input', {{ bubbles: true }}));
+                    input.dispatchEvent(new KeyboardEvent('keydown', {{ key: 'Enter', code: 'Enter', keyCode: 13, bubbles: true }}));
+                    input.dispatchEvent(new KeyboardEvent('keypress', {{ key: 'Enter', code: 'Enter', keyCode: 13, bubbles: true }}));
+                }} else if (retries > 0) {{
+                    setTimeout(function() {{ setSpanInput(data, retries - 1); }}, 200);
+                }}
             }}
+            setSpanInput(data, 5);
         }});
 
         // Persistent scroll restorer: watches for .gt-section to appear after rerun

--- a/tools/ground-truth-labeler/text_selector.py
+++ b/tools/ground-truth-labeler/text_selector.py
@@ -153,6 +153,15 @@ def render_selectable_job_text(job: dict, bridge_key: str = "span_bridge") -> No
                 end_char: endChar
             }});
 
+            // Save scroll positions of both columns before triggering rerun
+            var hBlock = sectionEl.closest('[data-testid="stHorizontalBlock"]');
+            if (hBlock) {{
+                var cols = hBlock.querySelectorAll(':scope > [data-testid="stColumn"]');
+                cols.forEach(function(col, i) {{
+                    sessionStorage.setItem('gt_col_scroll_' + i, col.scrollTop);
+                }});
+            }}
+
             // Find the hidden Streamlit text_input, set value, press Enter to trigger rerun
             var input = parentDoc.querySelector('input[aria-label="span_data"]');
             if (input) {{
@@ -166,6 +175,33 @@ def render_selectable_job_text(job: dict, bridge_key: str = "span_bridge") -> No
                 input.dispatchEvent(new KeyboardEvent('keypress', {{ key: 'Enter', code: 'Enter', keyCode: 13, bubbles: true }}));
             }}
         }});
+
+        // Persistent scroll restorer: watches for .gt-section to appear after rerun
+        if (!parentDoc._gtScrollObserver) {{
+            parentDoc._gtScrollObserver = new MutationObserver(function() {{
+                var s0 = sessionStorage.getItem('gt_col_scroll_0');
+                var s1 = sessionStorage.getItem('gt_col_scroll_1');
+                if (!s0 && !s1) return;
+
+                var section = parentDoc.querySelector('.gt-section');
+                if (!section) return;
+
+                var hBlock = section.closest('[data-testid="stHorizontalBlock"]');
+                if (!hBlock) return;
+
+                var cols = hBlock.querySelectorAll(':scope > [data-testid="stColumn"]');
+                if (cols.length < 2) return;
+
+                // Wait a tick for layout to settle
+                setTimeout(function() {{
+                    if (s0) cols[0].scrollTop = parseInt(s0, 10);
+                    if (s1) cols[1].scrollTop = parseInt(s1, 10);
+                    sessionStorage.removeItem('gt_col_scroll_0');
+                    sessionStorage.removeItem('gt_col_scroll_1');
+                }}, 100);
+            }});
+            parentDoc._gtScrollObserver.observe(parentDoc.body, {{ childList: true, subtree: true }});
+        }}
     }})();
     </script>
     """, height=0, width=0)

--- a/tools/ground-truth-labeler/text_selector.py
+++ b/tools/ground-truth-labeler/text_selector.py
@@ -1,0 +1,171 @@
+"""Text selection component for ground truth labeling.
+
+Uses a hidden Streamlit text_input as the JS→Python bridge.
+On mouseup, JS writes selection JSON to the hidden input and triggers
+its change event → Streamlit reruns → Python reads the value.
+
+This is the proven pattern for Streamlit JS↔Python communication.
+"""
+
+from __future__ import annotations
+
+import json
+
+import streamlit as st
+import streamlit.components.v1 as components
+
+SECTION_COLORS = {
+    "title": "rgba(33, 150, 243, 0.15)",
+    "description": "rgba(156, 39, 176, 0.15)",
+    "requirements": "rgba(76, 175, 80, 0.15)",
+    "responsibilities": "rgba(255, 152, 0, 0.15)",
+}
+
+SECTION_BORDER_COLORS = {
+    "title": "rgba(33, 150, 243, 0.5)",
+    "description": "rgba(156, 39, 176, 0.5)",
+    "requirements": "rgba(76, 175, 80, 0.5)",
+    "responsibilities": "rgba(255, 152, 0, 0.5)",
+}
+
+
+def _escape_html(text: str) -> str:
+    return (
+        text.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+        .replace("'", "&#39;")
+    )
+
+
+def span_input_bridge(key: str = "span_bridge") -> dict | None:
+    """Hidden text_input that receives span data from JS.
+
+    Renders a text_input hidden via CSS. The mouseup JS listener writes
+    to this input and triggers a change event → Streamlit rerun.
+
+    Returns span dict or None.
+    """
+    # Hidden text input — the JS bridge target
+    raw = st.text_input(
+        "span_data",
+        value="",
+        key=key,
+        label_visibility="collapsed",
+    )
+
+    # Hide it with CSS
+    st.markdown(
+        f"""<style>
+        div[data-testid="stTextInput"]:has(input[aria-label="span_data"]) {{
+            position: absolute;
+            top: -9999px;
+            opacity: 0;
+            height: 0;
+            overflow: hidden;
+        }}
+        </style>""",
+        unsafe_allow_html=True,
+    )
+
+    if raw and raw.strip():
+        try:
+            data = json.loads(raw)
+            if isinstance(data, dict) and "field_source" in data:
+                return data
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+    return None
+
+
+def render_selectable_job_text(job: dict, bridge_key: str = "span_bridge") -> None:
+    """Render color-coded job text with mouseup → hidden input bridge."""
+    sections = [
+        ("title", "Title", job.get("title", "")),
+        ("description", "Description", job.get("description", "")),
+        ("requirements", "Requirements", job.get("requirements", "")),
+        ("responsibilities", "Responsibilities", job.get("responsibilities", "")),
+    ]
+
+    all_html = ""
+    for field_source, label, text in sections:
+        if not text.strip():
+            continue
+        bg = SECTION_COLORS.get(field_source, "rgba(128,128,128,0.1)")
+        border = SECTION_BORDER_COLORS.get(field_source, "rgba(128,128,128,0.3)")
+        escaped = _escape_html(text[:4000])
+        all_html += (
+            f'<div class="gt-section" data-field="{field_source}" '
+            f'style="background:{bg}; border-left:3px solid {border}; '
+            f'padding:10px; border-radius:6px; margin-bottom:8px;">'
+            f'<div style="margin-bottom:4px;">'
+            f'<strong>&#x1F4CC; {label}</strong> '
+            f'<code style="font-size:0.7em; opacity:0.7;">{field_source}</code>'
+            f'</div>'
+            f'<div class="gt-section-text" data-field="{field_source}" '
+            f'style="white-space:pre-wrap; font-size:0.85em; line-height:1.5; '
+            f'cursor:text; user-select:text;">'
+            f'{escaped}</div></div>'
+        )
+
+    st.markdown(all_html, unsafe_allow_html=True)
+
+    # Inject mouseup listener that writes to the hidden Streamlit text_input
+    components.html(f"""
+    <script>
+    (function() {{
+        var parentDoc = window.parent.document;
+        if (parentDoc._gtSelListener) return;
+        parentDoc._gtSelListener = true;
+
+        parentDoc.addEventListener("mouseup", function() {{
+            var sel = parentDoc.getSelection();
+            if (!sel || sel.isCollapsed || !sel.toString().trim()) return;
+
+            var selectedText = sel.toString().trim();
+
+            var node = sel.anchorNode;
+            var sectionEl = null;
+            while (node && node !== parentDoc.body) {{
+                if (node.nodeType === 1 && node.classList &&
+                    node.classList.contains("gt-section-text")) {{
+                    sectionEl = node;
+                    break;
+                }}
+                node = node.parentNode;
+            }}
+            if (!sectionEl) return;
+
+            var fieldSource = sectionEl.getAttribute("data-field");
+            var range = sel.getRangeAt(0);
+            var preRange = parentDoc.createRange();
+            preRange.setStart(sectionEl, 0);
+            preRange.setEnd(range.startContainer, range.startOffset);
+            var startChar = preRange.toString().length;
+            var endChar = startChar + selectedText.length;
+
+            var data = JSON.stringify({{
+                text: selectedText,
+                field_source: fieldSource,
+                start_char: startChar,
+                end_char: endChar
+            }});
+
+            // Find the hidden Streamlit text_input, set value, press Enter to trigger rerun
+            var input = parentDoc.querySelector('input[aria-label="span_data"]');
+            if (input) {{
+                input.focus();
+                var nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+                    window.parent.HTMLInputElement.prototype, 'value'
+                ).set;
+                nativeInputValueSetter.call(input, data);
+                input.dispatchEvent(new Event('input', {{ bubbles: true }}));
+                input.dispatchEvent(new KeyboardEvent('keydown', {{ key: 'Enter', code: 'Enter', keyCode: 13, bubbles: true }}));
+                input.dispatchEvent(new KeyboardEvent('keypress', {{ key: 'Enter', code: 'Enter', keyCode: 13, bubbles: true }}));
+            }}
+        }});
+    }})();
+    </script>
+    """, height=0, width=0)

--- a/tools/ground-truth-labeler/text_selector.py
+++ b/tools/ground-truth-labeler/text_selector.py
@@ -117,10 +117,13 @@ def render_selectable_job_text(job: dict, bridge_key: str = "span_bridge") -> No
     <script>
     (function() {{
         var parentDoc = window.parent.document;
-        if (parentDoc._gtSelListener) return;
-        parentDoc._gtSelListener = true;
 
-        parentDoc.addEventListener("mouseup", function() {{
+        // Remove previous listener if any, then install fresh
+        if (parentDoc._gtSelHandler) {{
+            parentDoc.removeEventListener("mouseup", parentDoc._gtSelHandler);
+        }}
+
+        parentDoc._gtSelHandler = function() {{
             var sel = parentDoc.getSelection();
             if (!sel || sel.isCollapsed || !sel.toString().trim()) return;
 
@@ -179,7 +182,8 @@ def render_selectable_job_text(job: dict, bridge_key: str = "span_bridge") -> No
                 }}
             }}
             setSpanInput(data, 5);
-        }});
+        }};
+        parentDoc.addEventListener("mouseup", parentDoc._gtSelHandler);
 
         // Persistent scroll restorer: watches for .gt-section to appear after rerun
         if (!parentDoc._gtScrollObserver) {{


### PR DESCRIPTION
## Summary
Lightweight Streamlit tool for hand-labeling our ground truth dataset. Search JSearch for real El Paso postings and label skills/tools through a step-by-step form — no hand-crafting JSON.

### Features
- **JSearch integration** — search for real postings, cached locally (survives refresh)
- **5-step wizard** — Search → Review → Label Skills → Label Tools → Save
- **Drag-to-select source_span** — highlight text in the job posting to auto-capture `field_source`, `start_char`, `end_char`, and evidence text
- **Split-pane layout** — form on left, independently scrollable job text on right (scroll position preserved across reruns)
- **Schema-aligned** — outputs valid `SkillRecord`/`ToolRecord` JSON matching PR #64 `extraction_types.py`
- **Auto-append** — each labeled record appends to `ground_truth_labeled.json`
- **Edit/delete** on every labeled skill and tool
- **Dark mode** support
- **UTF-8 mojibake fix** for JSearch API responses
- **Labeling examples** — see `ground-truth-examples.md` for 5 reference records

### Design decisions
- `SpanRecord.text` captures the evidence phrase; skill/tool label is user-typed (supports inferred skills from surrounding context)
- `SpanRecord` offsets validated by Pydantic (`end_char - start_char == len(text)`, `start_char >= 0`)

## Setup

```bash
cd tools/ground-truth-labeler
python -m venv venv
venv\Scriptsctivate                    # Windows
source venv/bin/activate                  # macOS/Linux
pip install -r requirements.txt           # or: python -m pip install -r requirements.txt
cp .env.example .env                      # add your JSEARCH_API_KEY
```

## Run

```bash
python -m streamlit run app.py
```

## Target
20–30 labeled postings covering traditional roles (5–8), GenAI roles (~30–40%), and ambiguous items.

Looking for feedback on schema alignment and workflow before we build the full dataset.