### PR TITLE
fix: normalize ground truth schema and fix eval harness

### DIFF
--- a/agents/docs/runbooks/WEEK04_TESTING_RUNBOOK.md
+++ b/agents/docs/runbooks/WEEK04_TESTING_RUNBOOK.md
@@ -115,7 +115,7 @@ agents/
   |
   eval/
     extraction_eval.py           <-- Evaluation harness (precision/recall)
-    extraction_ground_truth.json <-- 30-50 hand-labeled records
+    extraction_ground_truth.json <-- 25 hand-labeled records (target: 30-50)
     cost_projection.py           <-- Cost analysis from llm_audit_log
   |
   scripts/
@@ -609,7 +609,7 @@ Expected: Either no rows (all calls succeeded) or rows with meaningful `error_re
 
 ### What it does
 
-Compares extraction output against a hand-labeled ground truth dataset of 30-50 job postings. Computes precision and recall for skills and tools extraction.
+Compares extraction output against a hand-labeled ground truth dataset of job postings. Computes precision and recall for skills and tools extraction. Currently at 25 records (target: 30-50).
 
 ### Key files
 
@@ -627,6 +627,36 @@ Compares extraction output against a hand-labeled ground truth dataset of 30-50 
 - **Writes:** Nothing — prints metrics to stdout
 - **LLM cost:** Depends on extraction method used (real LLM = cost; stub = free)
 
+### Ground truth record schema
+
+Each record contains:
+
+| Field              | Type       | Description                                                  |
+| ------------------ | ---------- | ------------------------------------------------------------ |
+| `ground_truth_id`  | string     | Sequential ID (`gt-001` through `gt-025`)                    |
+| `external_id`      | string     | Source-specific job ID                                       |
+| `source`           | string     | `JSearch` or scrape source                                   |
+| `title`            | string     | Job title                                                    |
+| `company`          | string     | Employer name                                                |
+| `city`, `state`    | string     | Location                                                     |
+| `description`      | string     | Full job description text                                    |
+| `requirements`     | string     | Requirements section text                                    |
+| `responsibilities` | string     | Responsibilities section text                                |
+| `skills`           | array      | Hand-labeled skills with `skill_name`, `type`, `confidence`, `required_flag`, `esco_uri`, `is_genai_extension`, `source_span` |
+| `tools`            | array      | Hand-labeled tools with `tool_name`, `category`, `confidence`, `is_genai_tool`, `source_span` |
+| `labeler_notes`    | object     | Free-form labeler annotations                                |
+
+### Current coverage
+
+| Role category            | Records |
+| ------------------------ | ------- |
+| AI Product Managers      | 6       |
+| Agile Project Managers   | 5       |
+| Data Analysts            | 5       |
+| Full Stack Developers    | 5       |
+| ML Engineers             | 4       |
+| **Total**                | **25**  |
+
 ### Test steps
 
 **Step 1 — Verify ground truth dataset:**
@@ -635,7 +665,7 @@ Compares extraction output against a hand-labeled ground truth dataset of 30-50 
 python agents/scripts/test_ground_truth.py
 ```
 
-Expected: 30-50 records with keys like `title`, `text`, `skills`, `tools`.
+Expected: 25 records with keys: `ground_truth_id`, `external_id`, `source`, `title`, `company`, `city`, `state`, `description`, `requirements`, `responsibilities`, `skills`, `tools`, `labeler_notes`.
 
 **Step 2 — Run the evaluation harness:**
 
@@ -643,7 +673,25 @@ Expected: 30-50 records with keys like `title`, `text`, `skills`, `tools`.
 python -m agents.eval.extraction_eval
 ```
 
-Expected output: Per-record and aggregate precision/recall metrics.
+Expected output: Per-record breakdown showing GT vs predicted skills/tools with set intersections, then aggregate metrics:
+
+```
+=== FINAL METRICS ===
+Total GT Skills: 177
+Total Pred Skills: <N>
+Matched Skills: <N>
+Skills Precision: <0-1>
+Skills Recall:    <0-1>
+
+--- TOOLS ---
+Total GT Tools: 104
+Total Pred Tools: <N>
+Matched Tools: <N>
+Tools Precision: <0-1>
+Tools Recall:    <0-1>
+```
+
+> **Note:** The default eval uses `extract_from_text_testing()` — a keyword-matching baseline (no LLM). Expect low precision/recall (~0.28/0.11 for skills, ~0.43/0.10 for tools). Switch to `extract_from_text()` for LLM-based extraction (requires Azure OpenAI env vars and incurs cost).
 
 **Step 3 — Record baseline metrics:**
 
@@ -652,11 +700,13 @@ After running the harness, update `agents/eval/prompt_iteration_log.md` with the
 ### Troubleshooting
 
 
-| Symptom                                           | Cause                               | Fix                                                       |
-| ------------------------------------------------- | ----------------------------------- | --------------------------------------------------------- |
-| `FileNotFoundError: extraction_ground_truth.json` | File missing                        | Verify `agents/eval/` directory                           |
-| Very low precision (<50%)                         | Extractor producing false positives | Check confidence threshold (`SKILL_CONFIDENCE_THRESHOLD`) |
-| Very low recall (<50%)                            | Extractor missing skills            | Check prompt template or extraction logic                 |
+| Symptom                                           | Cause                               | Fix                                                                 |
+| ------------------------------------------------- | ----------------------------------- | ------------------------------------------------------------------- |
+| `FileNotFoundError: extraction_ground_truth.json` | File missing                        | Verify `agents/eval/` directory                                     |
+| `UnicodeDecodeError: 'charmap'`                   | Windows CP1252 encoding             | Ensure file reads use `encoding="utf-8"`                            |
+| `KeyError: 'skill_name'`                          | Old records using `label` key       | Run schema normalization (rename `label` → `skill_name` in records) |
+| Very low precision (<50%)                         | Extractor producing false positives | Check confidence threshold (`SKILL_CONFIDENCE_THRESHOLD`)           |
+| Very low recall (<50%)                            | Extractor missing skills            | Check prompt template or extraction logic                           |
 
 
 ---

--- a/agents/eval/extraction_eval.py
+++ b/agents/eval/extraction_eval.py
@@ -64,7 +64,7 @@ def extract_from_text_testing(text: str) -> dict:
 
 
 def load_ground_truth(path: Path):
-    with open(path) as f:  # noqa: UP015
+    with open(path, encoding="utf-8") as f:
         return json.load(f)
 
 
@@ -100,9 +100,11 @@ def run_eval(ground_truth_path: str):
     total_matched_tools = 0
 
     for job in data:
-        text = job.get("text", job["title"])  # fallback if no text field
+        text = " ".join(
+            job.get(f, "") for f in ("title", "description", "requirements", "responsibilities")
+        )
 
-        gt_skills = normalize_list([s["label"] for s in job["skills"]])
+        gt_skills = normalize_list([s["skill_name"] for s in job["skills"]])
         gt_tools = normalize_list([t["tool_name"] for t in job["tools"]])
 
         pred = extract_from_text_testing(text)

--- a/agents/eval/extraction_ground_truth.json
+++ b/agents/eval/extraction_ground_truth.json
@@ -1,4789 +1,9577 @@
 [
+
   {
+
     "ground_truth_id": "gt-001",
+
     "external_id": "manual-43c1ae63",
+
     "source": "JSearch",
+
     "title": "Product Manager - AI & Data Analytics",
+
     "company": "WorkWave",
+
     "city": "Remote",
+
     "state": "NJ",
+
     "description": "We are seeking a results-oriented Product Manager to drive the vision and execution of our customer-facing SaaS products, data-driven features, and AI/ML solutions. This role is a critical bridge, translating deep technical capabilities from data science and engineering into clear, quantifiable business value for our B2B SaaS customers.\n\nThis is a highly visible, customer-facing role that involves working directly with key clients to co-develop innovative solutions. The ideal candidate is a curious, data-minded problem-solver who is excited to bridge the gap between business needs and technical solutions. This is a growth role where you will have a major impact on our product and our customers.",
+
     "requirements": "- Experience: 3-5+ years of relevant experience in one of the fields described above.\n- Product & Business Acumen: A strong ability to connect complex technical features directly to customer value, user needs, and business outcomes (like ROI or retention).\n- Customer Collaboration: Experience working directly with customers or key stakeholders to gather requirements, validate ideas, and manage feedback loops.\n- Communication & Stakeholder Management: Excellent communication and data storytelling skills. You can build consensus and manage expectations with diverse audiences (from engineering to sales to external clients).\n- Prioritization & Planning: A demonstrated ability to manage a backlog, make trade-offs, and align teams on a clear set of priorities.\n- SQL Proficiency: You have solid SQL fundamentals and are comfortable writing queries (like joins and aggregations) to explore data and conduct analysis.\n- BI Tool Proficiency: Experience with a modern BI platform (e.g., Tableau, Looker, Power BI, Sigma).\n- Data Fluency: A strong functional understanding of data transformation techniques.",
+
     "responsibilities": "- Own the product vision and strategic roadmap for our external, customer-facing AI/ML models, data products, and analytics features.\n- Engage directly with strategic customers and design partners to understand their needs, validate roadmaps, and co-develop new features.\n- Define, measure, and communicate product success using metrics that correlate with customer value and SaaS business metrics.\n- Partner with UX, Data Science, and Sales Engineering to create impactful data visualizations and product demos.\n- Define clear, testable requirements (epics and user stories) based on customer feedback, market analysis, and strategic priorities.\n- Work closely with data scientists to define requirements for AI/ML-driven features.",
+
     "skills": [
+
       {
+
         "skill_id": null,
+
         "skill_name": "Product strategy",
+
         "type": "Soft",
+
         "confidence": 0.95,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Own the product vision and strategic roadmap",
+
           "field_source": "responsibilities",
+
           "start_char": 2,
+
           "end_char": 46
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Stakeholder management",
+
         "type": "Soft",
+
         "confidence": 0.9,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Communication & Stakeholder Management",
+
           "field_source": "requirements",
+
           "start_char": 234,
+
           "end_char": 272
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "SQL",
+
         "type": "Technical",
+
         "confidence": 0.95,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "SQL Proficiency",
+
           "field_source": "requirements",
+
           "start_char": 420,
+
           "end_char": 435
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Data visualization",
+
         "type": "Technical",
+
         "confidence": 0.9,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "BI Tool Proficiency",
+
           "field_source": "requirements",
+
           "start_char": 570,
+
           "end_char": 589
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Backlog management",
+
         "type": "Soft",
+
         "confidence": 0.85,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "manage a backlog, make trade-offs",
+
           "field_source": "requirements",
+
           "start_char": 370,
+
           "end_char": 402
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "AI/ML lifecycle",
+
         "type": "Technical",
+
         "confidence": 0.8,
+
         "required_flag": false,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "AI/ML-driven features",
+
           "field_source": "responsibilities",
+
           "start_char": 480,
+
           "end_char": 501
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       }
+
     ],
+
     "tools": [
+
       {
+
         "tool_id": null,
+
         "tool_name": "Tableau",
+
         "category": "platform",
+
         "confidence": 0.9,
+
         "is_genai_tool": false,
+
         "source_span": {
+
           "text": "Tableau",
+
           "field_source": "requirements",
+
           "start_char": 592,
+
           "end_char": 599
+
         }
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Looker",
+
         "category": "platform",
+
         "confidence": 0.9,
+
         "is_genai_tool": false,
+
         "source_span": {
+
           "text": "Looker",
+
           "field_source": "requirements",
+
           "start_char": 601,
+
           "end_char": 607
+
         }
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Power BI",
+
         "category": "platform",
+
         "confidence": 0.9,
+
         "is_genai_tool": false,
+
         "source_span": {
+
           "text": "Power BI",
+
           "field_source": "requirements",
+
           "start_char": 609,
+
           "end_char": 617
+
         }
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Snowflake",
+
         "category": "database",
+
         "confidence": 0.85,
+
         "is_genai_tool": false,
+
         "source_span": {
+
           "text": "Snowflake",
+
           "field_source": "description",
+
           "start_char": 0,
+
           "end_char": 9
+
         }
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "DBT",
+
         "category": "devops",
+
         "confidence": 0.8,
+
         "is_genai_tool": false,
+
         "source_span": {
+
           "text": "DBT",
+
           "field_source": "description",
+
           "start_char": 0,
+
           "end_char": 3
+
         }
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Python",
+
         "category": "language",
+
         "confidence": 0.75,
+
         "is_genai_tool": false,
+
         "source_span": {
+
           "text": "Python",
+
           "field_source": "description",
+
           "start_char": 0,
+
           "end_char": 6
+
         }
+
       }
+
     ],
+
     "labeler_notes": {}
+
   },
+
   {
+
     "ground_truth_id": "gt-002",
+
     "external_id": "manual-aaa3511e",
+
     "source": "JSearch",
+
     "title": "Senior Product Manager, AI",
+
     "company": "Rocket Lawyer",
+
     "city": "Remote",
+
     "state": "CA",
+
     "description": "Have a passion for helping people through technology - especially AI? Come help Rocket Lawyer disrupt the legal industry and live up to our mission to make the law affordable and simple. You'll work at the forefront of agentic AI product development to build and launch cutting-edge products for millions of customers.",
+
     "requirements": "8-10 years of software Product Development experience ideally with B2B or B2C SaaS products. At least 4 years in AI/ML product management. Ability to combine a strong product sense with business acumen to deliver positive outcomes to customers and the business. Excellent communication skills. Experience building or launching products that leverage agentic AI systems.",
+
     "responsibilities": "Translate business and customer needs into delightful AI-powered products. Drive a structured innovation process for generating and evaluating innovative product concepts that leverage new AI capabilities. Continuously monitor and analyze the global AI landscape including breakthroughs in foundation models and agentic AI. Collaborate with data scientists and engineers to define data pipeline requirements. Work with partners to launch novel AI-powered features in strategic ecosystems. Define and analyze metrics to determine business impact. Lead the ideation, development, and launch of products for customers.",
+
     "skills": [
+
       {
+
         "skill_id": null,
+
         "skill_name": "AI/ML product management",
+
         "type": "Soft",
+
         "confidence": 0.95,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "AI/ML product management",
+
           "field_source": "requirements",
+
           "start_char": 110,
+
           "end_char": 134
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Agentic AI",
+
         "type": "Technical",
+
         "confidence": 0.9,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": true,
+
         "source_span": {
+
           "text": "agentic AI product development",
+
           "field_source": "description",
+
           "start_char": 217,
+
           "end_char": 247
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Product roadmap",
+
         "type": "Soft",
+
         "confidence": 0.9,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Develop and deliver a Roadmap",
+
           "field_source": "responsibilities",
+
           "start_char": 0,
+
           "end_char": 29
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Foundation models (LLMs)",
+
         "type": "Technical",
+
         "confidence": 0.85,
+
         "required_flag": false,
+
         "esco_uri": null,
+
         "is_genai_extension": true,
+
         "source_span": {
+
           "text": "breakthroughs in foundation models and agentic AI",
+
           "field_source": "responsibilities",
+
           "start_char": 265,
+
           "end_char": 314
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Customer research",
+
         "type": "Soft",
+
         "confidence": 0.85,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "understand the needs of our customers",
+
           "field_source": "responsibilities",
+
           "start_char": 0,
+
           "end_char": 37
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Cross-functional collaboration",
+
         "type": "Soft",
+
         "confidence": 0.85,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Collaborate with data scientists and engineers",
+
           "field_source": "responsibilities",
+
           "start_char": 315,
+
           "end_char": 361
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       }
+
     ],
+
     "tools": [
+
       {
+
         "tool_id": null,
+
         "tool_name": "ChatGPT",
+
         "category": "ai_tool",
+
         "confidence": 0.8,
+
         "is_genai_tool": true,
+
         "source_span": {
+
           "text": "ChatGPT Apps",
+
           "field_source": "responsibilities",
+
           "start_char": 0,
+
           "end_char": 12
+
         }
+
       }
+
     ],
+
     "labeler_notes": {}
+
   },
+
   {
+
     "ground_truth_id": "gt-003",
+
     "external_id": "manual-6f5bf734",
+
     "source": "JSearch",
+
     "title": "Senior Product Manager, AI Platforms",
+
     "company": "Peach",
+
     "city": "Remote",
+
     "state": "CA",
+
     "description": "We're looking for a Senior Product Manager to lead the next generation of AI-powered features at Peach. This is a strategic, cross-functional role focused on building and scaling AI capabilities within servicing, collections, and compliance workflows. You'll define product strategy, lead execution, and help shape how AI is applied across the Peach platform.",
+
     "requirements": "10+ years of Product Management experience, ideally in fintech, credit, payments, or similar regulated domains. Proven experience building or launching AI-powered products, ideally involving Agentic AI, NLP, chat/voice automation, or compliance tools. Strong analytical skills including SQL fluency, experimentation, and metrics definition. Excellent written and verbal communication skills across technical and business audiences.",
+
     "responsibilities": "Own the AI product roadmap across servicing, collections, and compliance. Translate operational workflows and lender pain points into clear AI feature requirements. Lead cross-functional teams to design, build, and ship AI features. Evaluate and integrate with third-party AI providers. Work closely with legal and compliance teams to ensure all AI solutions meet regulatory standards. Instrument AI features for performance measurement and drive continuous iteration.",
+
     "skills": [
+
       {
+
         "skill_id": null,
+
         "skill_name": "AI product roadmap",
+
         "type": "Soft",
+
         "confidence": 0.95,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Own the AI product roadmap",
+
           "field_source": "responsibilities",
+
           "start_char": 0,
+
           "end_char": 26
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Agentic AI",
+
         "type": "Technical",
+
         "confidence": 0.9,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": true,
+
         "source_span": {
+
           "text": "Agentic AI",
+
           "field_source": "requirements",
+
           "start_char": 191,
+
           "end_char": 201
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "NLP",
+
         "type": "Technical",
+
         "confidence": 0.85,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": true,
+
         "source_span": {
+
           "text": "NLP",
+
           "field_source": "requirements",
+
           "start_char": 203,
+
           "end_char": 206
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Cross-functional leadership",
+
         "type": "Soft",
+
         "confidence": 0.9,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Lead cross-functional teams",
+
           "field_source": "responsibilities",
+
           "start_char": 222,
+
           "end_char": 249
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "SQL",
+
         "type": "Technical",
+
         "confidence": 0.9,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "SQL fluency",
+
           "field_source": "requirements",
+
           "start_char": 258,
+
           "end_char": 269
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Regulatory compliance",
+
         "type": "Domain",
+
         "confidence": 0.85,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "meet regulatory standards",
+
           "field_source": "responsibilities",
+
           "start_char": 370,
+
           "end_char": 395
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Vendor management",
+
         "type": "Soft",
+
         "confidence": 0.85,
+
         "required_flag": false,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Evaluate and integrate with third-party AI providers",
+
           "field_source": "responsibilities",
+
           "start_char": 251,
+
           "end_char": 303
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Metrics definition",
+
         "type": "Technical",
+
         "confidence": 0.85,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "metrics definition",
+
           "field_source": "requirements",
+
           "start_char": 285,
+
           "end_char": 303
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       }
+
     ],
+
     "tools": [
+
       {
+
         "tool_id": null,
+
         "tool_name": "SQL",
+
         "category": "other",
+
         "confidence": 0.9,
+
         "is_genai_tool": false,
+
         "source_span": {
+
           "text": "SQL fluency",
+
           "field_source": "requirements",
+
           "start_char": 258,
+
           "end_char": 269
+
         }
+
       }
+
     ],
+
     "labeler_notes": {}
+
   },
+
   {
+
     "ground_truth_id": "gt-004",
+
     "external_id": "manual-3cd8ed39",
+
     "source": "JSearch",
+
     "title": "AI Product Manager",
+
     "company": "YipitData / SpendHound",
+
     "city": "Remote",
+
     "state": "NY",
+
     "description": "We are building towards an agent-first approach to vendor selection and price benchmarking. Looking for an AI Product Manager to lead the development of new AI features on our roadmap. You will help define the product vision, collaborate with engineering and design teams, and work closely with customers to achieve this goal.",
+
     "requirements": "Minimum 3+ years of experience in Product Management with 1+ years of experience building AI products. Ability to work closely with engineers in a highly technical environment. Comfortable analyzing data, doing error analysis, and using insights to guide product decisions. Familiarity with SQL, data visualization tools, or basic coding knowledge.",
+
     "responsibilities": "Define and drive the vision, strategy, and roadmap for SpendHound AI features. Conduct user interviews, analyze customer feedback, and study market trends. Work closely with engineering, design, and procurement expert teams. Act as the voice of the customer ensuring product decisions align with real user needs.",
+
     "skills": [
+
       {
+
         "skill_id": null,
+
         "skill_name": "AI product management",
+
         "type": "Soft",
+
         "confidence": 0.95,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "1+ years of experience building AI products",
+
           "field_source": "requirements",
+
           "start_char": 58,
+
           "end_char": 101
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Agentic AI",
+
         "type": "Technical",
+
         "confidence": 0.9,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": true,
+
         "source_span": {
+
           "text": "agent-first approach",
+
           "field_source": "description",
+
           "start_char": 27,
+
           "end_char": 47
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Product roadmap",
+
         "type": "Soft",
+
         "confidence": 0.9,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "new AI features on our roadmap",
+
           "field_source": "description",
+
           "start_char": 153,
+
           "end_char": 183
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Customer research",
+
         "type": "Soft",
+
         "confidence": 0.9,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Conduct user interviews, analyze customer feedback, and study market trends.",
+
           "field_source": "responsibilities",
+
           "start_char": 79,
+
           "end_char": 155
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Cross-functional collaboration",
+
         "type": "Soft",
+
         "confidence": 0.85,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Work closely with engineering, design, and procurement expert teams",
+
           "field_source": "responsibilities",
+
           "start_char": 156,
+
           "end_char": 223
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Data analysis",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "analyzing data, doing error analysis,",
+
           "field_source": "requirements",
+
           "start_char": 189,
+
           "end_char": 226
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "SQL",
+
         "type": "Technical",
+
         "confidence": 0.85,
+
         "required_flag": false,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Familiarity with SQL",
+
           "field_source": "requirements",
+
           "start_char": 274,
+
           "end_char": 294
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       }
+
     ],
+
     "tools": [
+
       {
+
         "tool_id": null,
+
         "tool_name": "Claude",
+
         "category": "ai_tool",
+
         "confidence": 0.85,
+
         "is_genai_tool": true,
+
         "source_span": null
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Cursor",
+
         "category": "ai_tool",
+
         "confidence": 0.85,
+
         "is_genai_tool": true,
+
         "source_span": null
+
       }
+
     ],
+
     "labeler_notes": {}
+
   },
+
   {
+
     "ground_truth_id": "gt-005",
+
     "external_id": "manual-five9-001",
+
     "source": "JSearch",
+
     "title": "Principal Product Manager - AI Applications",
+
     "company": "Five9",
+
     "city": "Remote",
+
     "state": "US",
+
     "description": "We're looking for a visionary product leader who combines deep technical expertise with exceptional strategic thinking to lead the development of several strategic AI/LLM powered product areas, including AI Insights, Agent Assist, and GenAI Studio.",
+
     "requirements": "9+ years of product management experience, including 5+ years in AI-first enterprise software. Demonstrable hands-on success designing and delivering AI/LLM-powered CX applications. Proven technical proficiency with LLM applications, prompt engineering, RAG architectures, and agentic design patterns. Strong analytical skills. Experience managing beta programs and validating product directions through user feedback.",
+
     "responsibilities": "Define and communicate a bold product strategy that aligns with market trends and customer needs. Build and maintain a clear, prioritized roadmap. Conduct deep competitive and market analysis. Partner with Engineering and UX for flawless delivery. Collaborate with Marketing, Sales and Partner organizations. Act as a product evangelist in key customer conversations.",
+
     "skills": [
+
       {
+
         "skill_id": null,
+
         "skill_name": "LLM product management",
+
         "type": "Technical",
+
         "confidence": 0.95,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": true,
+
         "source_span": {
+
           "text": "AI/LLM-powered CX applications",
+
           "field_source": "requirements",
+
           "start_char": 97,
+
           "end_char": 127
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Prompt engineering",
+
         "type": "Technical",
+
         "confidence": 0.95,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": true,
+
         "source_span": {
+
           "text": "prompt engineering",
+
           "field_source": "requirements",
+
           "start_char": 175,
+
           "end_char": 193
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "RAG architecture",
+
         "type": "Technical",
+
         "confidence": 0.95,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": true,
+
         "source_span": {
+
           "text": "RAG architectures",
+
           "field_source": "requirements",
+
           "start_char": 195,
+
           "end_char": 212
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Agentic AI",
+
         "type": "Technical",
+
         "confidence": 0.9,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": true,
+
         "source_span": {
+
           "text": "agentic design patterns",
+
           "field_source": "requirements",
+
           "start_char": 218,
+
           "end_char": 241
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Product roadmap",
+
         "type": "Soft",
+
         "confidence": 0.95,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Build and maintain a clear, prioritized roadmap",
+
           "field_source": "responsibilities",
+
           "start_char": 0,
+
           "end_char": 47
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Competitive analysis",
+
         "type": "Technical",
+
         "confidence": 0.9,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Conduct deep competitive and market analysis",
+
           "field_source": "responsibilities",
+
           "start_char": 0,
+
           "end_char": 44
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Beta program management",
+
         "type": "Soft",
+
         "confidence": 0.85,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Experience managing beta programs",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 33
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Cross-functional leadership",
+
         "type": "Soft",
+
         "confidence": 0.85,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "leading through influence in matrixed, global organizations",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 59
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       }
+
     ],
+
     "tools": [
+
       {
+
         "tool_id": null,
+
         "tool_name": "LLM Ops",
+
         "category": "ai_tool",
+
         "confidence": 0.9,
+
         "is_genai_tool": true,
+
         "source_span": {
+
           "text": "Advanced LLM Ops and observability",
+
           "field_source": "description",
+
           "start_char": 0,
+
           "end_char": 34
+
         }
+
       }
+
     ],
+
     "labeler_notes": {}
+
   },
+
   {
+
     "ground_truth_id": "gt-006",
+
     "external_id": "manual-invoca-001",
+
     "source": "JSearch",
+
     "title": "Staff Product Manager - Voice AI",
+
     "company": "Invoca",
+
     "city": "Remote",
+
     "state": "US",
-    "description": "As a Staff Product Manager, Voice AI, you'll lead the vision and strategy for Invoca's Voice AI Agent capabilities â€” intelligent, autonomous systems that can converse naturally and take purposeful action in real time. You'll define the roadmap that fuses conversation intelligence, speech synthesis, and large language models (LLMs) with agentic AI frameworks.",
+
+    "description": "As a Staff Product Manager, Voice AI, you'll lead the vision and strategy for Invoca's Voice AI Agent capabilities — intelligent, autonomous systems that can converse naturally and take purposeful action in real time. You'll define the roadmap that fuses conversation intelligence, speech synthesis, and large language models (LLMs) with agentic AI frameworks.",
+
     "requirements": "7+ years of experience in product management with B2B SaaS or enterprise AI experience. 2+ years in conversational AI, voice assistants, or agent-based systems. Strong foundational knowledge of agentic AI concepts. Familiarity with modern AI orchestration frameworks such as LangChain or OpenAI ReAct. Strong understanding of conversational AI technologies including speech ASR, TTS, NLU, and LLMs.",
+
     "responsibilities": "Define and execute Invoca's Voice AI Agent roadmap. Partner with engineering and data science teams to integrate agentic AI patterns. Drive the definition and evolution of agent behavior and prompting strategy. Influence Invoca's approach to AI governance, reliability, and human oversight. Lead full-lifecycle product management from discovery through launch. Define success metrics and measure product impact through data and experimentation.",
+
     "skills": [
+
       {
+
         "skill_id": null,
+
         "skill_name": "Agentic AI",
+
         "type": "Technical",
+
         "confidence": 0.95,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": true,
+
         "source_span": {
+
           "text": "agentic AI frameworks",
+
           "field_source": "description",
+
           "start_char": 0,
+
           "end_char": 21
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Prompt engineering",
+
         "type": "Technical",
+
         "confidence": 0.95,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": true,
+
         "source_span": {
+
           "text": "agent behavior and prompting strategy",
+
           "field_source": "responsibilities",
+
           "start_char": 0,
+
           "end_char": 37
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "LLM product management",
+
         "type": "Technical",
+
         "confidence": 0.95,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": true,
+
         "source_span": {
+
           "text": "large language models (LLMs)",
+
           "field_source": "description",
+
           "start_char": 0,
+
           "end_char": 28
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Conversational AI",
+
         "type": "Technical",
+
         "confidence": 0.95,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "conversational AI technologies",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 30
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "AI governance",
+
         "type": "Technical",
+
         "confidence": 0.9,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": true,
+
         "source_span": {
+
           "text": "AI governance, reliability, and human oversight",
+
           "field_source": "responsibilities",
+
           "start_char": 0,
+
           "end_char": 47
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Product roadmap",
+
         "type": "Soft",
+
         "confidence": 0.95,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Define and execute Invoca's Voice AI Agent roadmap",
+
           "field_source": "responsibilities",
+
           "start_char": 0,
+
           "end_char": 50
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Data-driven decision making",
+
         "type": "Technical",
+
         "confidence": 0.85,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Define success metrics and continuously measure product impact through data, experimentation",
+
           "field_source": "responsibilities",
+
           "start_char": 0,
+
           "end_char": 91
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Cross-functional collaboration",
+
         "type": "Soft",
+
         "confidence": 0.85,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Partner with engineering and data science teams",
+
           "field_source": "responsibilities",
+
           "start_char": 0,
+
           "end_char": 47
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       }
+
     ],
+
     "tools": [
+
       {
+
         "tool_id": null,
+
         "tool_name": "LangChain",
+
         "category": "framework",
+
         "confidence": 0.9,
+
         "is_genai_tool": true,
+
         "source_span": {
+
           "text": "LangChain",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 9
+
         }
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Twilio",
+
         "category": "platform",
+
         "confidence": 0.75,
+
         "is_genai_tool": false,
+
         "source_span": {
+
           "text": "Twilio",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 6
+
         }
+
       }
+
     ],
+
     "labeler_notes": {}
+
   },
+
   {
+
     "ground_truth_id": "gt-007",
+
     "external_id": "zTsjTrYG_sZQSAp-AAAAAA==",
+
     "source": "JSearch",
+
     "title": "Agile Project Manager Contractor",
+
     "company": "BCforward",
+
     "city": "Seattle",
+
     "state": "Washington",
-    "description": "Job Title: Agile Project Manager Contractor\n\nLocation: Redmond, WA (Onsite, 5 days/week)\n\nDuration: 6 months\n\nPay Range: Up to $66/hr (W2)\n\nJob ID: 370730\n\nAbout BCforward\n\nBCforward is a leading global IT consulting and workforce solutions firm providing services and support to Fortune 500 and government clients. Founded in 1998, BCforward has grown with our customers needs into a full-service business solutions provider. With delivery centers and offices across North America and India, we take pride in building long-term relationships and delivering excellence through innovation, collaboration, and integrity.\n\nJob Description\n\nWe are seeking an Agile Project Manager Contractor. The ideal candidate will have expert-level experience in IT program management support and a proven ability to drive agile delivery, manage risks, and communicate status to stakeholders.\n\nResponsibilities:\nâ€¢ Facilitate agile ceremonies including daily stand-ups, sprint planning, reviews, and retrospectives.\nâ€¢ Track and manage project scope, schedule, and deliverables to meet goals and timelines.\nâ€¢ Identify, document, and mitigate risks and issues impacting delivery.\nâ€¢ Communicate project status, metrics, and updates to stakeholders and leadership.\nâ€¢ Ensure adherence to agile methodologies and best practices across teams.\n\nRequired Skills & Qualifications:\nâ€¢ Expert-level IT program management support experience in agile environments.\nâ€¢ Proven facilitation of Scrum or Kanban ceremonies and delivery workflows.\nâ€¢ Strong risk, issue, and dependency management with clear escalation practices.\nâ€¢ Clear stakeholder communication and reporting using standard project metrics.\nâ€¢ Experience level: 10+ years in program or project management roles.\n\nPreferred Skills:\nâ€¢ Experience working with consulting clients and cross-functional delivery teams.\nâ€¢ Familiarity with tools such as Jira, Confluence, or similar.\n\nWhy BCforward?\n\nAt BCforward, we believe in advancing lives and careers. When you join our team, you gain access to:\nâ€¢ Competitive compensation and benefits.\nâ€¢ Opportunities for growth with global clients.\nâ€¢ A supportive, inclusive culture that values innovation and people.\nâ€¢ Exposure to cutting-edge technologies and projects.\n\nAbout Our Commitment\n\nBCforward is an equal opportunity employer. We value diversity and are committed to creating an inclusive environment for all employees. All qualified applicants will receive consideration for employment without regard to race, color, religion, gender, sexual orientation, gender identity, national origin, age, disability, or veteran status.\n\nInterested? Apply Now!\n\nIf this aligns with your background, please apply with your most recent resumes\n\nEmail:\n\nNumber:\n317.210.8535\n\nEmployee Type\nContractor\n\nLocation\nSeattle, WA (Onsite)\n\nJob Type\nInformation Technology\n\nExperience\nNot Specified\n\nDate Posted\n03/10/2026",
+
+    "description": "Job Title: Agile Project Manager Contractor\n\nLocation: Redmond, WA (Onsite, 5 days/week)\n\nDuration: 6 months\n\nPay Range: Up to $66/hr (W2)\n\nJob ID: 370730\n\nAbout BCforward\n\nBCforward is a leading global IT consulting and workforce solutions firm providing services and support to Fortune 500 and government clients. Founded in 1998, BCforward has grown with our customers needs into a full-service business solutions provider. With delivery centers and offices across North America and India, we take pride in building long-term relationships and delivering excellence through innovation, collaboration, and integrity.\n\nJob Description\n\nWe are seeking an Agile Project Manager Contractor. The ideal candidate will have expert-level experience in IT program management support and a proven ability to drive agile delivery, manage risks, and communicate status to stakeholders.\n\nResponsibilities:\n• Facilitate agile ceremonies including daily stand-ups, sprint planning, reviews, and retrospectives.\n• Track and manage project scope, schedule, and deliverables to meet goals and timelines.\n• Identify, document, and mitigate risks and issues impacting delivery.\n• Communicate project status, metrics, and updates to stakeholders and leadership.\n• Ensure adherence to agile methodologies and best practices across teams.\n\nRequired Skills & Qualifications:\n• Expert-level IT program management support experience in agile environments.\n• Proven facilitation of Scrum or Kanban ceremonies and delivery workflows.\n• Strong risk, issue, and dependency management with clear escalation practices.\n• Clear stakeholder communication and reporting using standard project metrics.\n• Experience level: 10+ years in program or project management roles.\n\nPreferred Skills:\n• Experience working with consulting clients and cross-functional delivery teams.\n• Familiarity with tools such as Jira, Confluence, or similar.\n\nWhy BCforward?\n\nAt BCforward, we believe in advancing lives and careers. When you join our team, you gain access to:\n• Competitive compensation and benefits.\n• Opportunities for growth with global clients.\n• A supportive, inclusive culture that values innovation and people.\n• Exposure to cutting-edge technologies and projects.\n\nAbout Our Commitment\n\nBCforward is an equal opportunity employer. We value diversity and are committed to creating an inclusive environment for all employees. All qualified applicants will receive consideration for employment without regard to race, color, religion, gender, sexual orientation, gender identity, national origin, age, disability, or veteran status.\n\nInterested? Apply Now!\n\nIf this aligns with your background, please apply with your most recent resumes\n\nEmail:\n\nNumber:\n317.210.8535\n\nEmployee Type\nContractor\n\nLocation\nSeattle, WA (Onsite)\n\nJob Type\nInformation Technology\n\nExperience\nNot Specified\n\nDate Posted\n03/10/2026",
+
     "requirements": "- The ideal candidate will have expert-level experience in IT program management support and a proven ability to drive agile delivery, manage risks, and communicate status to stakeholders\n- Expert-level IT program management support experience in agile environments\n- Proven facilitation of Scrum or Kanban ceremonies and delivery workflows\n- Strong risk, issue, and dependency management with clear escalation practices\n- Clear stakeholder communication and reporting using standard project metrics\n- Experience level: 10+ years in program or project management roles",
+
     "responsibilities": "- Facilitate agile ceremonies including daily stand-ups, sprint planning, reviews, and retrospectives\n- Track and manage project scope, schedule, and deliverables to meet goals and timelines\n- Identify, document, and mitigate risks and issues impacting delivery\n- Communicate project status, metrics, and updates to stakeholders and leadership\n- Ensure adherence to agile methodologies and best practices across teams",
+
     "skills": [
+
       {
+
         "skill_id": null,
+
         "skill_name": "Program Management",
+
         "type": "Soft",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "program management",
+
           "field_source": "description",
+
           "start_char": 1361,
+
           "end_char": 1379
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Scrum",
+
         "type": "Soft",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Scrum",
+
           "field_source": "description",
+
           "start_char": 1447,
+
           "end_char": 1452
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Kanban",
+
         "type": "Soft",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Kanban",
+
           "field_source": "description",
+
           "start_char": 1456,
+
           "end_char": 1462
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Risk managment",
+
         "type": "Soft",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Identify, document, and mitigate risks and issues impacting delivery.",
+
           "field_source": "description",
+
           "start_char": 1081,
+
           "end_char": 1150
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Stakeholder communication",
+
         "type": "Soft",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "stakeholder communication",
+
           "field_source": "description",
+
           "start_char": 1586,
+
           "end_char": 1611
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Client Consultation",
+
         "type": "Soft",
+
         "confidence": 1.0,
+
         "required_flag": false,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "consulting clients",
+
           "field_source": "description",
+
           "start_char": 1773,
+
           "end_char": 1791
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       }
+
     ],
+
     "tools": [
+
       {
+
         "tool_id": null,
+
         "tool_name": "Jira",
+
         "category": "platform",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Jira",
+
           "field_source": "description",
+
           "start_char": 1862,
+
           "end_char": 1866
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Confluence",
+
         "category": "platform",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Jira",
+
           "field_source": "description",
+
           "start_char": 1862,
+
           "end_char": 1866
+
         },
+
         "is_genai_tool": false
+
       }
+
     ],
+
     "labeler_notes": {}
+
   },
+
   {
+
     "ground_truth_id": "gt-008",
+
     "external_id": "LEZL7LkkLc8PU3D1AAAAAA==",
+
     "source": "JSearch",
+
     "title": "Senior Project Manager (Change Management)",
+
     "company": "Keybank",
+
     "city": "Seattle",
+
     "state": "Washington",
+
     "description": "Location:\n127 Public Square, Cleveland Ohio\n\nJob Profile Summary\n\nLeads large and complex, high-priority projects and/or supports critical programs which usually impact multiple Lines of Business (LOB) and/or functional areas and often require considerable resources and high levels of functional integration. Takes projects from original concept through final implementation using standard Project Management, Change Management and Risk Management methodologies and concepts. Sets and manages expectations for diverse project stakeholders through planning activities and maintains transparency via communication & reporting channels. Establishes and maintains a strong collaborative trusted advisor relationship.\n\nThis role is responsible for supporting the implementation of sustainable change management practices and creating and managing a communication strategy across Banking Group Portfolio Management (BGPM). This individual demonstrates a passion for continuous improvement and acts with a sense of urgency.\n\nJob Summary\n\nDevelops and/or leads change management planning, design and implementation, including communications and training.\n\nWorks with business leader to define scope of change plan; manages plan, facilitates scope changes, and creates value in the delivery of the change and communications plan that supports the diverse business goals and interests of multiple senior-level stakeholders.\n\nUnderstands various project delivery methodologies such as waterfall, agile, etc. Able to manage or coordinate with all types of projects. Contributes to continuous improvement of Key's project lifecycle.\n\nSupports the change associated with the identification, tracking, escalation and resolution of issues. Creates communication to outline any dependencies across projects and escalates risks.\n\nDrive effective partner communication and relationship management by acquiring comprehensive knowledge of the business by spending time with business partners; solving business problems; negotiating effectively and offering credible challenges. Comfortable\n\npresenting material to senior and executive levels of leadership.\n\nSkills\n\nStrong analytical skills to identify areas for improvement and to analyze data to measure the impact of improvement initiatives.\n\nAbility to work as part of multi-functional teams.\n\nExcellent presentation and communication skills, with the ability to collaboratively influence and challenge.\n\nMay specialize in one or more of the following areas: value stream mapping, business process analysis and reengineering, change management and measurement, and/or process-driven systems requirements.\n\nAdvanced level computer skills & knowledge in typical business software including Microsoft, Excel, PowerPoint, Outlook, Projects\n\nProficiency in process mapping and project management tools, such as Visio, Miro, and JIRA\n\nQualifications\n\nBachelor's degree or equivalent work experience\n\nMinimum 5 years of experience in business analysis, process improvement, or related roles within financial services (required).\n\nMinimum 5 years of experience in project leadership experience, including managing cross-functional teams and enterprise-level initiatives.\n\nExperience in commercial lending processes and portfolio management is a plus.\n\nCOMPENSATION AND BENEFITS\nThis position is eligible to earn a base salary in the range of $80,000.00 - $150,000.00 annually. Placement within the pay range may differ based upon various factors, including but not limited to skills, experience and geographic location. Compensation for this role also includes eligibility for incentive compensation which may include production, commission, and/or discretionary incentives.\n\nPlease click here for a list of benefits for which this position is eligible.\n\nKey has implemented an approach to employee workspaces which prioritizes in-office presence, while providing flexible options in circumstances where roles can be performed effectively in a mobile environment.\n\nJob Posting Expiration Date: 03/24/2026\n\nKeyCorp is an Equal Opportunity Employer committed to sustaining an inclusive culture. All qualified applicants will receive consideration for employment without regard to race, color, religion, sex, sexual orientation, gender identity, national origin, age, genetic information, pregnancy, disability, veteran status or any other characteristic protected by law.\n\nQualified individuals with disabilities or disabled veterans who are unable or limited in their ability to apply on this site may request reasonable accommodations by emailing HR_Compliance@keybank.com.\n\n#LI-Hybrid",
+
     "requirements": "- presenting material to senior and executive levels of leadership\n- Strong analytical skills to identify areas for improvement and to analyze data to measure the impact of improvement initiatives\n- Ability to work as part of multi-functional teams\n- Excellent presentation and communication skills, with the ability to collaboratively influence and challenge\n- May specialize in one or more of the following areas: value stream mapping, business process analysis and reengineering, change management and measurement, and/or process-driven systems requirements\n- Advanced level computer skills & knowledge in typical business software including Microsoft, Excel, PowerPoint, Outlook, Projects\n- Proficiency in process mapping and project management tools, such as Visio, Miro, and JIRA\n- Bachelor's degree or equivalent work experience\n- Minimum 5 years of experience in business analysis, process improvement, or related roles within financial services (required)\n- Minimum 5 years of experience in project leadership experience, including managing cross-functional teams and enterprise-level initiatives",
+
     "responsibilities": "- Leads large and complex, high-priority projects and/or supports critical programs which usually impact multiple Lines of Business (LOB) and/or functional areas and often require considerable resources and high levels of functional integration\n- Takes projects from original concept through final implementation using standard Project Management, Change Management and Risk Management methodologies and concepts\n- Sets and manages expectations for diverse project stakeholders through planning activities and maintains transparency via communication & reporting channels\n- Establishes and maintains a strong collaborative trusted advisor relationship\n- This role is responsible for supporting the implementation of sustainable change management practices and creating and managing a communication strategy across Banking Group Portfolio Management (BGPM)\n- This individual demonstrates a passion for continuous improvement and acts with a sense of urgency\n- Develops and/or leads change management planning, design and implementation, including communications and training\n- Works with business leader to define scope of change plan; manages plan, facilitates scope changes, and creates value in the delivery of the change and communications plan that supports the diverse business goals and interests of multiple senior-level stakeholders\n- Understands various project delivery methodologies such as waterfall, agile, etc\n- Able to manage or coordinate with all types of projects\n- Contributes to continuous improvement of Key's project lifecycle\n- Supports the change associated with the identification, tracking, escalation and resolution of issues\n- Creates communication to outline any dependencies across projects and escalates risks\n- Drive effective partner communication and relationship management by acquiring comprehensive knowledge of the business by spending time with business partners; solving business problems; negotiating effectively and offering credible challenges",
+
     "skills": [
+
       {
+
         "skill_id": null,
+
         "skill_name": "Project Management",
+
         "type": "Soft",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Project Management",
+
           "field_source": "description",
+
           "start_char": 389,
+
           "end_char": 407
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Change Management",
+
         "type": "Domain",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Change Management",
+
           "field_source": "description",
+
           "start_char": 409,
+
           "end_char": 426
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Risk Management",
+
         "type": "Domain",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Risk Management",
+
           "field_source": "description",
+
           "start_char": 431,
+
           "end_char": 446
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Stakeholder management",
+
         "type": "Soft",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Sets and manages expectations for diverse project stakeholders",
+
           "field_source": "description",
+
           "start_char": 475,
+
           "end_char": 537
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Communication Skills",
+
         "type": "Soft",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "communication",
+
           "field_source": "description",
+
           "start_char": 597,
+
           "end_char": 610
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Waterfall methodologies",
+
         "type": "Domain",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "waterfall,",
+
           "field_source": "description",
+
           "start_char": 1468,
+
           "end_char": 1478
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Agile skiils",
+
         "type": "Domain",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "agile",
+
           "field_source": "description",
+
           "start_char": 1479,
+
           "end_char": 1484
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Problem Solver",
+
         "type": "Soft",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "solving business problems",
+
           "field_source": "description",
+
           "start_char": 1964,
+
           "end_char": 1989
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Data Analysis",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "analyze data",
+
           "field_source": "description",
+
           "start_char": 2200,
+
           "end_char": 2212
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Teamwork Skills",
+
         "type": "Soft",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Ability to work as part of multi-functional teams.",
+
           "field_source": "description",
+
           "start_char": 2263,
+
           "end_char": 2313
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Value Stream Mapping",
+
         "type": "Domain",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "value stream mapping",
+
           "field_source": "description",
+
           "start_char": 2478,
+
           "end_char": 2498
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Business Process Reengineering",
+
         "type": "Domain",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "business process analysis and reengineering",
+
           "field_source": "description",
+
           "start_char": 2500,
+
           "end_char": 2543
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       }
+
     ],
+
     "tools": [
+
       {
+
         "tool_id": null,
+
         "tool_name": "Visio",
+
         "category": "other",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Visio",
+
           "field_source": "description",
+
           "start_char": 2823,
+
           "end_char": 2828
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Miro",
+
         "category": "other",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Miro",
+
           "field_source": "description",
+
           "start_char": 2830,
+
           "end_char": 2834
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Jira",
+
         "category": "other",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "JIRA",
+
           "field_source": "description",
+
           "start_char": 2840,
+
           "end_char": 2844
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Excel",
+
         "category": "other",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Microsoft, Excel,",
+
           "field_source": "description",
+
           "start_char": 2706,
+
           "end_char": 2723
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Powerpoint",
+
         "category": "other",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "PowerPoint",
+
           "field_source": "description",
+
           "start_char": 2724,
+
           "end_char": 2734
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Outlook",
+
         "category": "other",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Outlook",
+
           "field_source": "description",
+
           "start_char": 2736,
+
           "end_char": 2743
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Microsoft Projects",
+
         "category": "other",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Projects",
+
           "field_source": "description",
+
           "start_char": 2745,
+
           "end_char": 2753
+
         },
+
         "is_genai_tool": false
+
       }
+
     ],
+
     "labeler_notes": {}
+
   },
+
   {
+
     "ground_truth_id": "gt-009",
+
     "external_id": "XX62wUg9flqxvGt-AAAAAA==",
+
     "source": "JSearch",
+
     "title": "PROJECT MANAGER WITH AGILE",
+
     "company": "Aroha Technologies",
+
     "city": "Seattle",
+
     "state": "Washington",
+
     "description": "Project Manager with Agile\n\nJob Summary\nThe Project Manager will be responsible for overseeing and managing projects utilizing program management and Agile methodology. The individual will play a key role in ensuring successful project delivery within scope, on time, and within budget.\n\nKey Responsibilities\n1. Lead and manage the project team throughout the project lifecycle.\n2. Develop project plans, including scope, schedule, budget, and resource allocation.\n3. Implement agile methodology to drive project execution and delivery.\n4. Conduct regular project status meetings and provide updates to stakeholders.\n5. Identify and mitigate project risks to ensure successful project completion.\n6. Manage project documentation and facilitate knowledge transfer.\n7. Monitor and report on project progress, ensuring adherence to quality standards.\n8. Collaborate with cross functional teams to achieve project objectives.\n9. Drive continuous improvement initiatives within the project management process.\n10. Ensure alignment of project outcomes with business goals and objectives.\n\nSkill Requirements\n1. Strong proficiency in program management principles and practices.\n2. In-depth knowledge and experience in agile methodology and its application in project management.\n3. Exceptional leadership and communication skills to effectively lead project teams and collaborate with stakeholders.\n4. Ability to prioritize tasks, manage multiple projects concurrently, and adapt to changing priorities.\n5. Excellent problem-solving skills to address project challenges and implement effective solutions.\n6. Proficiency in project management tools and software for project planning, tracking, and reporting.\n\nExperience\n\n>11 Years\n\nQualification\n\nBachelor of Technology/ Engineering\n\nOther Requirement\n\nScrum Master\nLocation-Washington DC (5 days onsite)\n\nSkills:\nApplication Programming Interface (API), Artificial Intelligence (AI), Cloud Computing, Code Reviews, Continuous Deployment/Delivery, Continuous Integration, Conversation Engine, Customer Relations, Database Programming, Debugging Skills, DevOps, Docker, Documentation, Flask, Git, Mentoring, Microsoft .NET, Microsoft C# (C Sharp), Microsoft Windows Azure, Pytest, Python Programming/Scripting Language, REST (Representational State Transfer), React.js, Software Development, Unit Test, User Interface/Experience (UI/UX)\n\nAbout the Company:\nAroha Technologies",
+
     "requirements": "- Strong proficiency in program management principles and practices\n- In-depth knowledge and experience in agile methodology and its application in project management\n- Exceptional leadership and communication skills to effectively lead project teams and collaborate with stakeholders\n- Ability to prioritize tasks, manage multiple projects concurrently, and adapt to changing priorities\n- Excellent problem-solving skills to address project challenges and implement effective solutions\n- Proficiency in project management tools and software for project planning, tracking, and reporting\n- >11 Years\n- Bachelor of Technology/ Engineering\n- Scrum Master\n- Location-Washington DC (5 days onsite)\n- Application Programming Interface (API), Artificial Intelligence (AI), Cloud Computing, Code Reviews, Continuous Deployment/Delivery, Continuous Integration, Conversation Engine, Customer Relations, Database Programming, Debugging Skills, DevOps, Docker, Documentation, Flask, Git, Mentoring, Microsoft .NET, Microsoft C# (C Sharp), Microsoft Windows Azure, Pytest, Python Programming/Scripting Language, REST (Representational State Transfer), React.js, Software Development, Unit Test, User Interface/Experience (UI/UX)",
+
     "responsibilities": "- Project Manager with Agile\n- The Project Manager will be responsible for overseeing and managing projects utilizing program management and Agile methodology\n- The individual will play a key role in ensuring successful project delivery within scope, on time, and within budget\n- Lead and manage the project team throughout the project lifecycle\n- Develop project plans, including scope, schedule, budget, and resource allocation\n- Implement agile methodology to drive project execution and delivery\n- Conduct regular project status meetings and provide updates to stakeholders\n- Identify and mitigate project risks to ensure successful project completion\n- Manage project documentation and facilitate knowledge transfer\n- Monitor and report on project progress, ensuring adherence to quality standards\n- Collaborate with cross functional teams to achieve project objectives\n- Drive continuous improvement initiatives within the project management process\n- Ensure alignment of project outcomes with business goals and objectives",
+
     "skills": [
+
       {
+
         "skill_id": null,
+
         "skill_name": "Program Management",
+
         "type": "Soft",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "managing projects",
+
           "field_source": "description",
+
           "start_char": 98,
+
           "end_char": 115
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Agile",
+
         "type": "Domain",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Agile methodology",
+
           "field_source": "description",
+
           "start_char": 149,
+
           "end_char": 166
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Project Management",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Project Manager",
+
           "field_source": "description",
+
           "start_char": 43,
+
           "end_char": 58
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Leadership",
+
         "type": "Soft",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Lead and manage the project team throughout the project lifecycle.",
+
           "field_source": "description",
+
           "start_char": 308,
+
           "end_char": 374
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Stakeholder Management",
+
         "type": "Soft",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Conduct regular project status meetings and provide updates to stakeholders.",
+
           "field_source": "description",
+
           "start_char": 527,
+
           "end_char": 603
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Project Planning",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Manage project documentation and facilitate knowledge transfer.",
+
           "field_source": "description",
+
           "start_char": 681,
+
           "end_char": 744
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Cross-functional Collaboration",
+
         "type": "Soft",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Collaborate with cross functional teams to achieve project objectives.",
+
           "field_source": "description",
+
           "start_char": 826,
+
           "end_char": 896
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "API",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Application Programming Interface",
+
           "field_source": "description",
+
           "start_char": 1803,
+
           "end_char": 1836
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "AI Knowledge",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Artificial Intelligence",
+
           "field_source": "description",
+
           "start_char": 1844,
+
           "end_char": 1867
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Cloud Computing",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Cloud Computing",
+
           "field_source": "description",
+
           "start_char": 1874,
+
           "end_char": 1889
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "DevOps",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "DevOps",
+
           "field_source": "description",
+
           "start_char": 2042,
+
           "end_char": 2048
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Docker",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Docker",
+
           "field_source": "description",
+
           "start_char": 2049,
+
           "end_char": 2055
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       }
+
     ],
+
     "tools": [
+
       {
+
         "tool_id": null,
+
         "tool_name": "Flask",
+
         "category": "framework",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Flask",
+
           "field_source": "description",
+
           "start_char": 2073,
+
           "end_char": 2078
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": ".NET",
+
         "category": "framework",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Microsoft .NET",
+
           "field_source": "description",
+
           "start_char": 2096,
+
           "end_char": 2110
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Azure",
+
         "category": "platform",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Microsoft Windows Azure",
+
           "field_source": "description",
+
           "start_char": 2136,
+
           "end_char": 2159
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "C#",
+
         "category": "language",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Microsoft C# (C Sharp)",
+
           "field_source": "description",
+
           "start_char": 2112,
+
           "end_char": 2134
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "PyTest",
+
         "category": "framework",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Pytest",
+
           "field_source": "description",
+
           "start_char": 2161,
+
           "end_char": 2167
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Python",
+
         "category": "language",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Python Programming/Scripting Language",
+
           "field_source": "requirements",
+
           "start_char": 1043,
+
           "end_char": 1080
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "React.js",
+
         "category": "framework",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "React.js",
+
           "field_source": "description",
+
           "start_char": 2248,
+
           "end_char": 2256
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Git",
+
         "category": "devops",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Git",
+
           "field_source": "description",
+
           "start_char": 2080,
+
           "end_char": 2083
+
         },
+
         "is_genai_tool": false
+
       }
+
     ],
+
     "labeler_notes": {}
+
   },
+
   {
+
     "ground_truth_id": "gt-010",
+
     "external_id": "cxCeHUCfrTXMmAVtAAAAAA==",
+
     "source": "JSearch",
+
     "title": "Senior Project Manager - Agile",
+
     "company": "Procom Consultants Group",
+
     "city": "Seattle",
+
     "state": "Washington",
+
     "description": "Company Description\n\nProcom is a leading provider of professional IT services and staffing to businesses and governments in Canada.\n\nWith revenues over $500 million, the Branham Group has recognized Procom as the 3rd largest professional services firm in Canada and is now the largest \"Canadian-Owned\" IT staffing/consulting company.\n\nProcom's areas of staffing expertise include:\nApplication Development\nProject Management\nQuality Assurance\nBusiness/Systems Analysis\nDatawarehouse & Business Intelligence\nInfrastructure & Network Services\nRisk Management & Compliance\nBusiness Continuity & Disaster Recovery\nSecurity & Privacy\n\nSpecialties Contract Staffing (Staff Augmentation)\nPermanent Placement (Staff Augmentation)\nICAP (Contractor Payroll)\nFlextrack (Vendor Management System)\n\nJob Description\n\nSenior Project Manager - Agile\n\nOn behalf of our client, Procom Services is searching for a Senior Project Manager - Agile for a contract opportunity in Seattle, WA.\n\nSenior Project Manager - Agile Job Details\n\nSenior Project Manager to develop and manage project plans and deliverables to support the development of Analytics Visualization Tool suite. Lead team through sprint planning sessions and daily stand-ups.\n\nOther responsibilities include:\n\nProvides input to determine project scope, schedule and budget baselines based on an understanding of the system development lifecycle.\n\nNegotiates changes to project baselines.\n\nConducts design and user reviews.\n\nMonitors project deliverables to ensure compliance with quality standards.\n\nIdentifies and negotiates for necessary resources to meet project goals.\n\nDevelops and executes project communication plans.\n\nLeads activities to identify project risks and develop mitigation plans.\n\nSenior Project Manager - Agile Mandatory Skills\n\nMust have experience managing Agile projects.\n\nExcellent communication skills and ability to collaborate closely with business partners.\n\nExperience with leading projects in the domain of engineering data, 2D/3D graphics a plus.\n\nSenior Project Manager - Agile Start Date\n\nASAP\n\nSenior Project Manager - Agile Assignment Length\n\n6 Months\n\nAdditional Information\n\nAll your information will be kept confidential according to EEO guidelines. Please send your resume in Word format only.",
+
     "requirements": "- Senior Project Manager - Agile\n- On behalf of our client, Procom Services is searching for a Senior Project Manager - Agile for a contract opportunity in Seattle, WA\n- Senior Project Manager - Agile Job Details\n- Senior Project Manager - Agile Mandatory Skills\n- Must have experience managing Agile projects\n- Excellent communication skills and ability to collaborate closely with business partners\n- Senior Project Manager - Agile Start Date\n- Senior Project Manager - Agile Assignment Length\n- 6 Months",
+
     "responsibilities": "- Business Continuity & Disaster Recovery\n- Flextrack (Vendor Management System)\n- Senior Project Manager to develop and manage project plans and deliverables to support the development of Analytics Visualization Tool suite\n- Lead team through sprint planning sessions and daily stand-ups\n- Provides input to determine project scope, schedule and budget baselines based on an understanding of the system development lifecycle\n- Negotiates changes to project baselines\n- Conducts design and user reviews\n- Monitors project deliverables to ensure compliance with quality standards\n- Identifies and negotiates for necessary resources to meet project goals\n- Develops and executes project communication plans\n- Leads activities to identify project risks and develop mitigation plans",
+
     "skills": [
+
       {
+
         "skill_id": null,
+
         "skill_name": "Project Management",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Project Management",
+
           "field_source": "description",
+
           "start_char": 402,
+
           "end_char": 420
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Quality Assurance",
+
         "type": "Domain",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Quality Assurance",
+
           "field_source": "description",
+
           "start_char": 421,
+
           "end_char": 438
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "App Development",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Application Development",
+
           "field_source": "description",
+
           "start_char": 378,
+
           "end_char": 401
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Business Analysis",
+
         "type": "Domain",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Business/Systems Analysis",
+
           "field_source": "description",
+
           "start_char": 439,
+
           "end_char": 464
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Business Continuity",
+
         "type": "Domain",
+
         "confidence": 1.0,
+
         "required_flag": false,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Business Continuity & Disaster Recovery",
+
           "field_source": "description",
+
           "start_char": 566,
+
           "end_char": 605
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "SDLC(Software Development Life Cycle)",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Provides input to determine project scope, schedule and budget baselines based on an understanding of the system development lifecycle.",
+
           "field_source": "description",
+
           "start_char": 1242,
+
           "end_char": 1377
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Negotiation",
+
         "type": "Soft",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Negotiates changes to project baselines.",
+
           "field_source": "description",
+
           "start_char": 1378,
+
           "end_char": 1418
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Sprint Planning",
+
         "type": "Domain",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Develops and executes project communication plans.",
+
           "field_source": "description",
+
           "start_char": 1601,
+
           "end_char": 1651
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Communication Skills",
+
         "type": "Soft",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Excellent communication skills and ability to collaborate closely with business partners.",
+
           "field_source": "description",
+
           "start_char": 1819,
+
           "end_char": 1908
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "2D/3D Graphics Knowledge",
+
         "type": "Domain",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Experience with leading projects in the domain of engineering data, 2D/3D graphics a plus.",
+
           "field_source": "description",
+
           "start_char": 1909,
+
           "end_char": 1999
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       }
+
     ],
+
     "tools": [
+
       {
+
         "tool_id": null,
+
         "tool_name": "Flextrack",
+
         "category": "platform",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Flextrack (Vendor Management System)",
+
           "field_source": "description",
+
           "start_char": 743,
+
           "end_char": 779
+
         },
+
         "is_genai_tool": false
+
       }
+
     ],
+
     "labeler_notes": {}
+
   },
+
   {
+
     "ground_truth_id": "gt-011",
+
     "external_id": "bMEqAZVpPWx2TlHtAAAAAA==",
+
     "source": "JSearch",
+
     "title": "Agile Project Manager",
+
     "company": "Kaav, Inc.",
+
     "city": "Seattle",
+
     "state": "Washington",
+
     "description": "Outline of the Role:\nThe Agile Project Manager is responsible for ensuring the product team delivers its commitments to our\nbusiness partners. This role works lock step with our Product Management Team by diligently following the\nscrum framework to ensure the Scrum Capability Owner has prepared backlogs that are prioritized and\ngroomed, the team has estimated the sprint ahead, the active sprint has strong support on any impediments,\nand the team is able to rely on the scrum framework to guide the cadence of the product model. The Agile\nProject Manager is constantly seeking for ways to improve the team to get faster, tighter, stronger and\nbetter. A continuous improvement culture will be facilitated by this role.\n\nPrincipal Duties and Responsibilities:\n\no Analyze, evaluate, test, and oversee implementation of new and existing processes and procedures.\no Examine and collect data on existing processes to uncover areas for suggesting improvements and\ninnovation.\no Lead and facilitate Continuous Improvement events in our Global Product Team\no Drive process consistency across the Global Product Team\no Investigate and troubleshoot any problems that arise with processes, procedures, and operations.\no Regularly review business KPI's and determine ways to improve their ability to maintain or approve\nthose measures\no Effectively persuade others to implement process modifications and new approaches\no Conduct end-to-end process mapping insights from root cause analysis.\no Establish consistent Issues, Risk, and Dependency Management reporting across all findings and\nobservations.\no Highlight best practices, industry standards and Agile principles where guidance is needed\no Radiate information that helps with the moving parts of integrating the team, the initiatives, the\nsystems, and the organization\n\nQualifications, Skills, Experience and Personal Requirements:\n? 5+ years of scrum master / project manager role and experience in supply chain/retauk\n? Experience with retail and roll-out of new technologies, hardware and applications\n? Experience working in an agile development including tools like JIRA, Confluence and other project\nmanagement tools\n? Strong communication skills, team management?and ability to build relationships across cross-\nfunctional teams\n? Core understanding of software development ?\n? 2 or more years of experience managing global teams\n? Demonstrated experience of instilling a continuous improvement culture\n\nAdditional Manager Comments:\n? Proven work ethic with utmost integrity\n? Desire to excel and succeed\n? Actively live and breathe the client culture and lifestyle\n? Self-awareness, with a desire for constant self-improvement (goal -oriented)\n? Entrepreneurial spirit and an egoless nature\n? Self-motivated, passionate, empathetic, approachable\n? Outgoing, energetic, upbeat and fun!\n\nRequired Skills : Agile Methodology\nAdditional Skills : Project ManagerThis is a high PRIORITY requisition. This is a PROACTIVE requisition",
+
     "requirements": "- 5+ years of scrum master / project manager role and experience in supply chain/retauk\n- Experience with retail and roll-out of new technologies, hardware and applications\n- Experience working in an agile development including tools like JIRA, Confluence and other project\n- Strong communication skills, team management?and ability to build relationships across cross-\n- 2 or more years of experience managing global teams\n- Demonstrated experience of instilling a continuous improvement culture\n- Proven work ethic with utmost integrity\n- Desire to excel and succeed\n- Actively live and breathe the client culture and lifestyle\n- Self-awareness, with a desire for constant self-improvement (goal -oriented)\n- Entrepreneurial spirit and an egoless nature\n- Self-motivated, passionate, empathetic, approachable\n- Outgoing, energetic, upbeat and fun!\n- Required Skills : Agile Methodology\n- Additional Skills : Project ManagerThis is a high PRIORITY requisition",
+
     "responsibilities": "- The Agile Project Manager is responsible for ensuring the product team delivers its commitments to our\n- This role works lock step with our Product Management Team by diligently following the\n- scrum framework to ensure the Scrum Capability Owner has prepared backlogs that are prioritized and\n- groomed, the team has estimated the sprint ahead, the active sprint has strong support on any impediments,\n- and the team is able to rely on the scrum framework to guide the cadence of the product model\n- Project Manager is constantly seeking for ways to improve the team to get faster, tighter, stronger and\n- A continuous improvement culture will be facilitated by this role\n- Analyze, evaluate, test, and oversee implementation of new and existing processes and procedures\n- Examine and collect data on existing processes to uncover areas for suggesting improvements and\n- Lead and facilitate Continuous Improvement events in our Global Product Team\n- Drive process consistency across the Global Product Team\n- Investigate and troubleshoot any problems that arise with processes, procedures, and operations\n- Regularly review business KPI's and determine ways to improve their ability to maintain or approve\n- Effectively persuade others to implement process modifications and new approaches\n- Conduct end-to-end process mapping insights from root cause analysis\n- Establish consistent Issues, Risk, and Dependency Management reporting across all findings and\n- Highlight best practices, industry standards and Agile principles where guidance is needed\n- Radiate information that helps with the moving parts of integrating the team, the initiatives, the",
+
     "skills": [
+
       {
+
         "skill_id": null,
+
         "skill_name": "Agile",
+
         "type": "Domain",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Agile Methodology",
+
           "field_source": "description",
+
           "start_char": 2853,
+
           "end_char": 2870
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Scrum",
+
         "type": "Domain",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "scrum master",
+
           "field_source": "description",
+
           "start_char": 1890,
+
           "end_char": 1902
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Project Management",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "project manager role and experience in supply chain/retauk",
+
           "field_source": "description",
+
           "start_char": 1905,
+
           "end_char": 1963
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Communication Skills",
+
         "type": "Soft",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "communication skills",
+
           "field_source": "description",
+
           "start_char": 2176,
+
           "end_char": 2196
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Team Management",
+
         "type": "Soft",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "team management",
+
           "field_source": "description",
+
           "start_char": 2198,
+
           "end_char": 2213
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Software Development",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "software development",
+
           "field_source": "description",
+
           "start_char": 2304,
+
           "end_char": 2324
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Global Team Mangagement",
+
         "type": "Soft",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "managing global teams",
+
           "field_source": "description",
+
           "start_char": 2359,
+
           "end_char": 2380
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       }
+
     ],
+
     "tools": [
+
       {
+
         "tool_id": null,
+
         "tool_name": "Jira",
+
         "category": "other",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "JIRA",
+
           "field_source": "description",
+
           "start_char": 2115,
+
           "end_char": 2119
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Confluence",
+
         "category": "other",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Confluence",
+
           "field_source": "description",
+
           "start_char": 2121,
+
           "end_char": 2131
+
         },
+
         "is_genai_tool": false
+
       }
+
     ],
+
     "labeler_notes": {}
+
   },
+
   {
+
     "ground_truth_id": "gt-012",
+
     "external_id": "1bwo_fSl1DZXW5mXAAAAAA==",
+
     "source": "JSearch",
+
     "title": "Clinical Systems & Data Analyst I",
+
     "company": "El Paso MHMR D/B/A Emergence Health Network",
+
     "city": "El Paso",
+
     "state": "Texas",
-    "description": "Clinical Systems & Data Analyst I\n\nJob Code: CSDA - 115\nRevision Date: January 20, 2026\n\nStarting Salary: $22.60 hourly; $47,006 annually\n\nFLSA: Exempt\n\nOverview\n\nWe are an agency committed to innovative behavioral health services in trauma-informed care that promote healing and recovery to instill a sense of empowerment and foster a lifelong sense of resilience.\n\nGeneral Description\n\nThis position supports the setup, configuration, testing, and implementation of clinical application products and information systems while producing reports and dashboards that support data-driven decision-making. The role designs and supports clinical application processes, provides training and technical support to end users, and applies data query, basic statistical analysis, and data visualization tools to improve efficiency, reduce risk, and enhance customer and stakeholder satisfaction.\n\nThis position works under general supervision and independently determines work methods and priorities.\n\nDuties and Responsibilities\n\nThe functions listed below are those that represent the majority of the time spent working in this position. Management may assign additional functions related to the type of work of the position, as necessary.\nâ€¢ Support the setup, configuration, testing, and implementation of clinical applications, including electronic health records and related systems.\nâ€¢ Provide technical support to clinical users, including system access, troubleshooting, and issue resolution.\nâ€¢ Assist in evaluating user needs and translating requirements into system, workflow, and reporting solutions.\nâ€¢ Develop and maintain clinical system documentation and assist with end-user training.\nâ€¢ Create and support recurring and ad hoc reports and dashboards using data query and reporting tools.\nâ€¢ Analyze data to identify trends and support basic exploratory analysis and data integration.\nâ€¢ Present findings and provide training and ongoing support for reports and dashboards.\nâ€¢ Research relevant technologies and analytical tools and perform other duties as assigned.\nâ€¢ Performs other duties as assigned.\n\nMinimum Education and Experience Requirements\n\nRequires an Associates Degree in a technical or quantitative/business field supplemented by three (3) years of data analysis experience; or possession of any equivalent combination of education, training, and experience which provides the requisite knowledge, skills, and abilities.\n\nExperience with trauma-informed services; cognitive behavioral therapies, including Dialectical Behavioral Therapy (DBT); and motivational therapies including the use of incentives, preferred.\n\nRequired Knowledge and Abilities\n\nKnowledge of trauma-informed theories, principals, and practices (includes multi-faceted understanding of concepts such as community trauma, intergenerational and historical trauma, parallel processes, and universal precautions), preferred.\n\nPhysical Demands\n\nPerforms sedentary work that involves walking or standing some of the time and involves exerting up to 10 pounds of force on a regular and recurring basis or sustained keyboard operations.\n\nUnavoidable Hazards (Work Environment)\nâ€¢ Involves routine and frequent exposure to:\nâ€¢ * Bright/dim light; Dusts and pollen.\nâ€¢ Extreme heat and/or cold; Wet or humid conditions.\nâ€¢ Extreme noise levels, Animals/wildlife.\nâ€¢ Vibration; Fumes and/or noxious odors.\nâ€¢ Traffic; Moving machinery.\nâ€¢ Electrical shock; Heights.\nâ€¢ Radiation; Disease/pathogens.\nâ€¢ Toxic/caustic chemicals; Explosives; Violence.\nâ€¢ Other extreme hazards not listed above.\n\nSpecial Certifications and Licenses\nâ€¢ Must possess and maintain a valid state Driver's License with an acceptable driving record.\nâ€¢ Must be able to pass a TB, criminal background, and drug screen.\n\nAmericans with Disabilities Act Compliance (ADA)\n\nEmergence Health Network is an Equal Opportunity Employer. ADA requires Emergence Health Network to provide reasonable accommodations to qualified persons with disabilities. Prospective and current employees are encouraged to discuss ADA accommodations with management.\n\nOther Job Characteristics\nâ€¢ Staffing requirements, including criteria that staff have diverse disciplinary backgrounds, have necessary State required license and accreditation, and are culturally and linguistically trained to serve the needs of the clinic's patient population.\nâ€¢ Credentialed, certified, and licensed professionals with adequate training in person-centered, family centered, trauma informed, culturally-competent and recovery-oriented care.\nâ€¢ Responsible for adhering to the EHN common purpose and service framework to continuously provide exceptional care to all constituents.\n\nNote: This Class Description does not constitute an employment agreement between the Emergence Health Network and an employee and is subject to change by the Emergence Health Network as its needs change.",
+
+    "description": "Clinical Systems & Data Analyst I\n\nJob Code: CSDA - 115\nRevision Date: January 20, 2026\n\nStarting Salary: $22.60 hourly; $47,006 annually\n\nFLSA: Exempt\n\nOverview\n\nWe are an agency committed to innovative behavioral health services in trauma-informed care that promote healing and recovery to instill a sense of empowerment and foster a lifelong sense of resilience.\n\nGeneral Description\n\nThis position supports the setup, configuration, testing, and implementation of clinical application products and information systems while producing reports and dashboards that support data-driven decision-making. The role designs and supports clinical application processes, provides training and technical support to end users, and applies data query, basic statistical analysis, and data visualization tools to improve efficiency, reduce risk, and enhance customer and stakeholder satisfaction.\n\nThis position works under general supervision and independently determines work methods and priorities.\n\nDuties and Responsibilities\n\nThe functions listed below are those that represent the majority of the time spent working in this position. Management may assign additional functions related to the type of work of the position, as necessary.\n• Support the setup, configuration, testing, and implementation of clinical applications, including electronic health records and related systems.\n• Provide technical support to clinical users, including system access, troubleshooting, and issue resolution.\n• Assist in evaluating user needs and translating requirements into system, workflow, and reporting solutions.\n• Develop and maintain clinical system documentation and assist with end-user training.\n• Create and support recurring and ad hoc reports and dashboards using data query and reporting tools.\n• Analyze data to identify trends and support basic exploratory analysis and data integration.\n• Present findings and provide training and ongoing support for reports and dashboards.\n• Research relevant technologies and analytical tools and perform other duties as assigned.\n• Performs other duties as assigned.\n\nMinimum Education and Experience Requirements\n\nRequires an Associates Degree in a technical or quantitative/business field supplemented by three (3) years of data analysis experience; or possession of any equivalent combination of education, training, and experience which provides the requisite knowledge, skills, and abilities.\n\nExperience with trauma-informed services; cognitive behavioral therapies, including Dialectical Behavioral Therapy (DBT); and motivational therapies including the use of incentives, preferred.\n\nRequired Knowledge and Abilities\n\nKnowledge of trauma-informed theories, principals, and practices (includes multi-faceted understanding of concepts such as community trauma, intergenerational and historical trauma, parallel processes, and universal precautions), preferred.\n\nPhysical Demands\n\nPerforms sedentary work that involves walking or standing some of the time and involves exerting up to 10 pounds of force on a regular and recurring basis or sustained keyboard operations.\n\nUnavoidable Hazards (Work Environment)\n• Involves routine and frequent exposure to:\n• * Bright/dim light; Dusts and pollen.\n• Extreme heat and/or cold; Wet or humid conditions.\n• Extreme noise levels, Animals/wildlife.\n• Vibration; Fumes and/or noxious odors.\n• Traffic; Moving machinery.\n• Electrical shock; Heights.\n• Radiation; Disease/pathogens.\n• Toxic/caustic chemicals; Explosives; Violence.\n• Other extreme hazards not listed above.\n\nSpecial Certifications and Licenses\n• Must possess and maintain a valid state Driver's License with an acceptable driving record.\n• Must be able to pass a TB, criminal background, and drug screen.\n\nAmericans with Disabilities Act Compliance (ADA)\n\nEmergence Health Network is an Equal Opportunity Employer. ADA requires Emergence Health Network to provide reasonable accommodations to qualified persons with disabilities. Prospective and current employees are encouraged to discuss ADA accommodations with management.\n\nOther Job Characteristics\n• Staffing requirements, including criteria that staff have diverse disciplinary backgrounds, have necessary State required license and accreditation, and are culturally and linguistically trained to serve the needs of the clinic's patient population.\n• Credentialed, certified, and licensed professionals with adequate training in person-centered, family centered, trauma informed, culturally-competent and recovery-oriented care.\n• Responsible for adhering to the EHN common purpose and service framework to continuously provide exceptional care to all constituents.\n\nNote: This Class Description does not constitute an employment agreement between the Emergence Health Network and an employee and is subject to change by the Emergence Health Network as its needs change.",
+
     "requirements": "- Requires an Associates Degree in a technical or quantitative/business field supplemented by three (3) years of data analysis experience; or possession of any equivalent combination of education, training, and experience which provides the requisite knowledge, skills, and abilities\n- Extreme noise levels, Animals/wildlife\n- Vibration; Fumes and/or noxious odors\n- Electrical shock; Heights\n- Radiation; Disease/pathogens\n- Toxic/caustic chemicals; Explosives; Violence\n- Special Certifications and Licenses\n- Must possess and maintain a valid state Driver's License with an acceptable driving record\n- Must be able to pass a TB, criminal background, and drug screen\n- Staffing requirements, including criteria that staff have diverse disciplinary backgrounds, have necessary State required license and accreditation, and are culturally and linguistically trained to serve the needs of the clinic's patient population\n- Credentialed, certified, and licensed professionals with adequate training in person-centered, family centered, trauma informed, culturally-competent and recovery-oriented care\n- Responsible for adhering to the EHN common purpose and service framework to continuously provide exceptional care to all constituents",
+
     "responsibilities": "- This position supports the setup, configuration, testing, and implementation of clinical application products and information systems while producing reports and dashboards that support data-driven decision-making\n- The role designs and supports clinical application processes, provides training and technical support to end users, and applies data query, basic statistical analysis, and data visualization tools to improve efficiency, reduce risk, and enhance customer and stakeholder satisfaction\n- This position works under general supervision and independently determines work methods and priorities\n- Management may assign additional functions related to the type of work of the position, as necessary\n- Support the setup, configuration, testing, and implementation of clinical applications, including electronic health records and related systems\n- Provide technical support to clinical users, including system access, troubleshooting, and issue resolution\n- Assist in evaluating user needs and translating requirements into system, workflow, and reporting solutions\n- Develop and maintain clinical system documentation and assist with end-user training\n- Create and support recurring and ad hoc reports and dashboards using data query and reporting tools\n- Analyze data to identify trends and support basic exploratory analysis and data integration\n- Present findings and provide training and ongoing support for reports and dashboards\n- Research relevant technologies and analytical tools and perform other duties as assigned\n- Performs other duties as assigned\n- Performs sedentary work that involves walking or standing some of the time and involves exerting up to 10 pounds of force on a regular and recurring basis or sustained keyboard operations\n- Unavoidable Hazards (Work Environment)\n- Involves routine and frequent exposure to:\n- Bright/dim light; Dusts and pollen\n- Extreme heat and/or cold; Wet or humid conditions",
+
     "skills": [
+
       {
+
         "skill_id": null,
+
         "skill_name": "Clinical Systems Implementation",
+
         "type": "Technical",
+
         "confidence": 0.95,
+
         "required_flag": false,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Develop and maintain clinical system documentation and assist with end-user training",
+
           "field_source": "responsibilities",
+
           "start_char": 1063,
+
           "end_char": 1147
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Data Analysis & Statistics",
+
         "type": "Technical",
+
         "confidence": 0.95,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "statistical analysis",
+
           "field_source": "description",
+
           "start_char": 740,
+
           "end_char": 760
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Data Visualization",
+
         "type": "Technical",
+
         "confidence": 0.9,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "data visualization",
+
           "field_source": "description",
+
           "start_char": 766,
+
           "end_char": 784
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Requirements Analysis & Workflow Design",
+
         "type": "Technical",
+
         "confidence": 0.9,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Assist in evaluating user needs and translating requirements into system, workflow, and reporting solutions",
+
           "field_source": "responsibilities",
+
           "start_char": 955,
+
           "end_char": 1062
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Training & Communication",
+
         "type": "Soft",
+
         "confidence": 0.85,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "provides training and technical support to end users",
+
           "field_source": "description",
+
           "start_char": 656,
+
           "end_char": 708
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Trauma-Informed Care",
+
         "type": "Domain",
+
         "confidence": 0.75,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "We are an agency committed to innovative behavioral health services in trauma-informed care that promote healing and recovery to instill a sense of empowerment and foster a lifelong sense of resilience.",
+
           "field_source": "description",
+
           "start_char": 156,
+
           "end_char": 358
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       }
+
     ],
+
     "tools": [
+
       {
+
         "tool_id": null,
+
         "tool_name": "SQL Data Query Tools",
+
         "category": "language",
+
         "confidence": 0.85,
+
         "source_span": {
+
           "text": "Create and support recurring and ad hoc reports and dashboards using data query and reporting tools",
+
           "field_source": "description",
+
           "start_char": 1680,
+
           "end_char": 1779
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Electronic Health Record (EHR) Systems",
+
         "category": "platform",
+
         "confidence": 0.95,
+
         "source_span": {
+
           "text": "Support the setup, configuration, testing, and implementation of clinical applications, including electronic health records and related systems",
+
           "field_source": "responsibilities",
+
           "start_char": 703,
+
           "end_char": 846
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Data Visualization Tools",
+
         "category": "framework",
+
         "confidence": 0.8,
+
         "source_span": {
+
           "text": "data visualization tools to improve efficiency, reduce risk, and enhance customer and stakeholder satisfaction",
+
           "field_source": "description",
+
           "start_char": 766,
+
           "end_char": 876
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Reporting Tools",
+
         "category": "platform",
+
         "confidence": 0.85,
+
         "source_span": {
+
           "text": "Create and support recurring and ad hoc reports and dashboards using data query and reporting tools.",
+
           "field_source": "description",
+
           "start_char": 1680,
+
           "end_char": 1780
+
         },
+
         "is_genai_tool": false
+
       }
+
     ],
+
     "labeler_notes": {
+
       "Clinical Systems Implementation": "Involves setup, configuration, testing, and deployment of clinical applications",
+
       "Data Analysis & Statistics": "ncludes exploratory analysis, identifying trends, and applying statistical methods",
+
       "Data Visualization": "Creating dashboards and reports for decision-making",
+
       "Requirements Analysis & Workflow Design": "Translating user needs into system and reporting solutions",
+
       "Training & Communication": "Conducting end-user training and presenting findings",
+
       "Trauma-Informed Care": "Preferred domain knowledge in behavioral health and trauma-informed practices",
+
       "Electronic Health Record (EHR) Systems": "Core system being configured and supported",
+
       "Data Visualization Tools": "Used to present insights and trends",
+
       "Reporting Tools": "General reporting systems used for generating insights"
+
     }
+
   },
+
   {
+
     "ground_truth_id": "gt-013",
+
     "external_id": "-l_bpgPmbYEhVdx3AAAAAA==",
+
     "source": "JSearch",
+
     "title": "Junior Data Analyst",
+
     "company": "Steampunk",
+
     "city": "El Paso",
+
     "state": "Texas",
-    "description": "Overview:\n\nWe are looking for you to join our team as a Data Analyst. This position focuses on data analysis for law enforcement support, requiring a combination of investigative data expertise, analytical skills, and the ability to work under high-pressure, mission-critical environments. This role will involve working with diverse data sets, ensuring accuracy and integrity while supporting ongoing criminal and civil investigations.\n\nOur ideal candidate has a blend of technical acumen, attention to detail, and the ability to engage with law enforcement agencies. We are looking for more than just a \"Data Analyst\"â€”this role requires a technologist with excellent communication skills, customer service, and a passion for data and problem-solving.\n\nContributions:\n\nKey Responsibilities\nâ€¢ Data Analysis and Trend Recognition: Compile and analyze data from multiple sources, identifying trends across various data sets, locations, and targets.\nâ€¢ Data Accuracy and Assessment: Monitor data for accuracy, integrity, authenticity, and relevancy. Identify intelligence gaps and assess data viability for investigative purposes.\nâ€¢ Investigative Support: Collaborate with teams to examine data gathered from criminal and civil investigations, developing methodologies to exploit investigative information.\nâ€¢ Quality Control & Reporting: Participate in the development of work products, conducting periodic progress reviews and ensuring quality control of findings. Regularly report findings to lead personnel.\nâ€¢ Data Entry: Perform data entry from both hard and soft copies into large-scale data processing systems, utilizing tools like optical character readers, scanners, and digital cameras as appropriate.\nâ€¢ Law Enforcement Support: Provide critical law enforcement support, interacting with various agencies through multiple channels of communication, while managing data under tight timelines in a high-pressure environment.\nâ€¢ Data Visualization and Tools: Leverage MS Excel, Power BI, or similar tools to design and build formulas, charts, pivot tables, and manipulate unstructured data from different platforms.\nâ€¢ You will be part of our Data Exploitation Practice!\n\nQualifications:\n\nRequired\nâ€¢ Ability to hold a position of SECRET clearance level with the US government.\nâ€¢ Bachelor's Degree and 1 year of work experience OR 5 years of work experience and no degree.\nâ€¢ Experience using data analytic/visualization tools such as MS Excel, Power BI, or others to design charts, create formulas, and analyze unstructured data (can be job or education-based).\nâ€¢ Skilled at multi-tasking in a fast-paced environment while maintaining clear communications with stakeholders.\nâ€¢ Must be local to El, Paso TX or willing to drive on site 5 days a week.\nâ€¢ Applicants selected will be subject to a Government background investigation and must meet eligibility and suitability requirements.\nâ€¢ To support continuous operations, this role follows a rotating shift schedule. Candidates should be comfortable working flexible hours, including potential evenings or weekends.\n\nPreferred\nâ€¢ Experience providing support to a 24/7 law enforcement operations unit.\nâ€¢ Military or law enforcement background or exposure.\nâ€¢ Ability to manage multiple tasks in a high-paced environment, including collaboration\nwith various teams.\nâ€¢ Strong analytical skills for identifying trends, gaps, and ensuring data accuracy and\nâ€¢ Experience with documenting processes and developing SOPs for data handling and\nâ€¢ Demonstrated experience in reverse engineering and validation of data processes.\nâ€¢ Ability to communicate findings and updates effectively during briefings and team\n\nAbout steampunk:\n\nSteampunk relies on several factors to determine salary, including but not limited to geographic location, contractual requirements, education, knowledge, skills, competencies, and experience. The projected compensation range for this position is $35,000 to $60,000. The estimate displayed represents a typical annual salary range for this position. Annual salary is just one aspect of Steampunkâ€™s total compensation package for employees. Learn more about additional Steampunk benefits here.\n\nIdentity Statement\n\nAs part of the application process, you are expected to be on camera during interviews and assessments. We reserve the right to take your picture to verify your identity and prevent fraud.\n\nSteampunk is a Change Agent in the Federal contracting industry, bringing new thinking to clients in the Homeland, Federal Civilian, Health and DoD sectors. Through our Human-Centered delivery methodology, we are fundamentally changing the expectations our Federal clients have for true shared accountability in solving their toughest mission challenges. As an employee owned company, we focus on investing in our employees to enable them to do the greatest work of their careers â€“ and rewarding them for outstanding contributions to our growth. If you want to learn more about our story, visit http://www.steampunk.com.\n\nWe are an equal opportunity employer and all qualified applicants will receive consideration for employment without regard to race, color, religion, sex, national origin, disability status, protected veteran status, or any other characteristic protected by law. Steampunk participates in the E-Verify program.",
-    "requirements": "- Our ideal candidate has a blend of technical acumen, attention to detail, and the ability to engage with law enforcement agencies\n- We are looking for more than just a \"Data Analyst\"â€”this role requires a technologist with excellent communication skills, customer service, and a passion for data and problem-solving\n- Ability to hold a position of SECRET clearance level with the US government\n- Bachelor's Degree and 1 year of work experience OR 5 years of work experience and no degree\n- Experience using data analytic/visualization tools such as MS Excel, Power BI, or others to design charts, create formulas, and analyze unstructured data (can be job or education-based)\n- Skilled at multi-tasking in a fast-paced environment while maintaining clear communications with stakeholders\n- Must be local to El, Paso TX or willing to drive on site 5 days a week\n- Applicants selected will be subject to a Government background investigation and must meet eligibility and suitability requirements\n- Candidates should be comfortable working flexible hours, including potential evenings or weekends\n- with various teams\n- Strong analytical skills for identifying trends, gaps, and ensuring data accuracy and\n- Experience with documenting processes and developing SOPs for data handling and\n- Demonstrated experience in reverse engineering and validation of data processes\n- Ability to communicate findings and updates effectively during briefings and team",
+
+    "description": "Overview:\n\nWe are looking for you to join our team as a Data Analyst. This position focuses on data analysis for law enforcement support, requiring a combination of investigative data expertise, analytical skills, and the ability to work under high-pressure, mission-critical environments. This role will involve working with diverse data sets, ensuring accuracy and integrity while supporting ongoing criminal and civil investigations.\n\nOur ideal candidate has a blend of technical acumen, attention to detail, and the ability to engage with law enforcement agencies. We are looking for more than just a \"Data Analyst\"—this role requires a technologist with excellent communication skills, customer service, and a passion for data and problem-solving.\n\nContributions:\n\nKey Responsibilities\n• Data Analysis and Trend Recognition: Compile and analyze data from multiple sources, identifying trends across various data sets, locations, and targets.\n• Data Accuracy and Assessment: Monitor data for accuracy, integrity, authenticity, and relevancy. Identify intelligence gaps and assess data viability for investigative purposes.\n• Investigative Support: Collaborate with teams to examine data gathered from criminal and civil investigations, developing methodologies to exploit investigative information.\n• Quality Control & Reporting: Participate in the development of work products, conducting periodic progress reviews and ensuring quality control of findings. Regularly report findings to lead personnel.\n• Data Entry: Perform data entry from both hard and soft copies into large-scale data processing systems, utilizing tools like optical character readers, scanners, and digital cameras as appropriate.\n• Law Enforcement Support: Provide critical law enforcement support, interacting with various agencies through multiple channels of communication, while managing data under tight timelines in a high-pressure environment.\n• Data Visualization and Tools: Leverage MS Excel, Power BI, or similar tools to design and build formulas, charts, pivot tables, and manipulate unstructured data from different platforms.\n• You will be part of our Data Exploitation Practice!\n\nQualifications:\n\nRequired\n• Ability to hold a position of SECRET clearance level with the US government.\n• Bachelor's Degree and 1 year of work experience OR 5 years of work experience and no degree.\n• Experience using data analytic/visualization tools such as MS Excel, Power BI, or others to design charts, create formulas, and analyze unstructured data (can be job or education-based).\n• Skilled at multi-tasking in a fast-paced environment while maintaining clear communications with stakeholders.\n• Must be local to El, Paso TX or willing to drive on site 5 days a week.\n• Applicants selected will be subject to a Government background investigation and must meet eligibility and suitability requirements.\n• To support continuous operations, this role follows a rotating shift schedule. Candidates should be comfortable working flexible hours, including potential evenings or weekends.\n\nPreferred\n• Experience providing support to a 24/7 law enforcement operations unit.\n• Military or law enforcement background or exposure.\n• Ability to manage multiple tasks in a high-paced environment, including collaboration\nwith various teams.\n• Strong analytical skills for identifying trends, gaps, and ensuring data accuracy and\n• Experience with documenting processes and developing SOPs for data handling and\n• Demonstrated experience in reverse engineering and validation of data processes.\n• Ability to communicate findings and updates effectively during briefings and team\n\nAbout steampunk:\n\nSteampunk relies on several factors to determine salary, including but not limited to geographic location, contractual requirements, education, knowledge, skills, competencies, and experience. The projected compensation range for this position is $35,000 to $60,000. The estimate displayed represents a typical annual salary range for this position. Annual salary is just one aspect of Steampunk’s total compensation package for employees. Learn more about additional Steampunk benefits here.\n\nIdentity Statement\n\nAs part of the application process, you are expected to be on camera during interviews and assessments. We reserve the right to take your picture to verify your identity and prevent fraud.\n\nSteampunk is a Change Agent in the Federal contracting industry, bringing new thinking to clients in the Homeland, Federal Civilian, Health and DoD sectors. Through our Human-Centered delivery methodology, we are fundamentally changing the expectations our Federal clients have for true shared accountability in solving their toughest mission challenges. As an employee owned company, we focus on investing in our employees to enable them to do the greatest work of their careers – and rewarding them for outstanding contributions to our growth. If you want to learn more about our story, visit http://www.steampunk.com.\n\nWe are an equal opportunity employer and all qualified applicants will receive consideration for employment without regard to race, color, religion, sex, national origin, disability status, protected veteran status, or any other characteristic protected by law. Steampunk participates in the E-Verify program.",
+
+    "requirements": "- Our ideal candidate has a blend of technical acumen, attention to detail, and the ability to engage with law enforcement agencies\n- We are looking for more than just a \"Data Analyst\"—this role requires a technologist with excellent communication skills, customer service, and a passion for data and problem-solving\n- Ability to hold a position of SECRET clearance level with the US government\n- Bachelor's Degree and 1 year of work experience OR 5 years of work experience and no degree\n- Experience using data analytic/visualization tools such as MS Excel, Power BI, or others to design charts, create formulas, and analyze unstructured data (can be job or education-based)\n- Skilled at multi-tasking in a fast-paced environment while maintaining clear communications with stakeholders\n- Must be local to El, Paso TX or willing to drive on site 5 days a week\n- Applicants selected will be subject to a Government background investigation and must meet eligibility and suitability requirements\n- Candidates should be comfortable working flexible hours, including potential evenings or weekends\n- with various teams\n- Strong analytical skills for identifying trends, gaps, and ensuring data accuracy and\n- Experience with documenting processes and developing SOPs for data handling and\n- Demonstrated experience in reverse engineering and validation of data processes\n- Ability to communicate findings and updates effectively during briefings and team",
+
     "responsibilities": "- This position focuses on data analysis for law enforcement support, requiring a combination of investigative data expertise, analytical skills, and the ability to work under high-pressure, mission-critical environments\n- This role will involve working with diverse data sets, ensuring accuracy and integrity while supporting ongoing criminal and civil investigations\n- Data Analysis and Trend Recognition: Compile and analyze data from multiple sources, identifying trends across various data sets, locations, and targets\n- Data Accuracy and Assessment: Monitor data for accuracy, integrity, authenticity, and relevancy\n- Identify intelligence gaps and assess data viability for investigative purposes\n- Investigative Support: Collaborate with teams to examine data gathered from criminal and civil investigations, developing methodologies to exploit investigative information\n- Quality Control & Reporting: Participate in the development of work products, conducting periodic progress reviews and ensuring quality control of findings\n- Regularly report findings to lead personnel\n- Data Entry: Perform data entry from both hard and soft copies into large-scale data processing systems, utilizing tools like optical character readers, scanners, and digital cameras as appropriate\n- Law Enforcement Support: Provide critical law enforcement support, interacting with various agencies through multiple channels of communication, while managing data under tight timelines in a high-pressure environment\n- Data Visualization and Tools: Leverage MS Excel, Power BI, or similar tools to design and build formulas, charts, pivot tables, and manipulate unstructured data from different platforms\n- You will be part of our Data Exploitation Practice!\n- To support continuous operations, this role follows a rotating shift schedule",
+
     "skills": [
+
       {
+
         "skill_id": null,
+
         "skill_name": "Data Analysis & Trend Recognition",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Data Analysis and Trend Recognition: Compile and analyze data from multiple sources, identifying trends across various data sets, locations, and targets.",
+
           "field_source": "description",
+
           "start_char": 789,
+
           "end_char": 942
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Data Quality & Integrity Assessment",
+
         "type": "Technical",
+
         "confidence": 0.95,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Data Accuracy and Assessment: Monitor data for accuracy, integrity, authenticity, and relevancy. Identify intelligence gaps and assess data viability for investigative purposes",
+
           "field_source": "description",
+
           "start_char": 945,
+
           "end_char": 1121
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Investigative Data Analysis",
+
         "type": "Technical",
+
         "confidence": 0.9,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Investigative Support: Collaborate with teams to examine data gathered from criminal and civil investigations, developing methodologies to exploit investigative information.",
+
           "field_source": "description",
+
           "start_char": 1125,
+
           "end_char": 1298
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Data Visualization & Reporting",
+
         "type": "Technical",
+
         "confidence": 0.95,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Data Visualization and Tools: Leverage MS Excel, Power BI, or similar tools to design and build formulas, charts, pivot tables, and manipulate unstructured data from different platforms.",
+
           "field_source": "description",
+
           "start_char": 1926,
+
           "end_char": 2112
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Attention to Detail",
+
         "type": "Soft",
+
         "confidence": 0.9,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Our ideal candidate has a blend of technical acumen, attention to detail, and the ability to engage with law enforcement agencies",
+
           "field_source": "description",
+
           "start_char": 436,
+
           "end_char": 565
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Communication & Stakeholder Coordination",
+
         "type": "Soft",
+
         "confidence": 0.9,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
-          "text": "Our ideal candidate has a blend of technical acumen, attention to detail, and the ability to engage with law enforcement agencies. We are looking for more than just a \"Data Analyst\"â€”this role requires a technologist with excellent communication skills, customer service, and a passion for data and problem-solving.",
+
+          "text": "Our ideal candidate has a blend of technical acumen, attention to detail, and the ability to engage with law enforcement agencies. We are looking for more than just a \"Data Analyst\"—this role requires a technologist with excellent communication skills, customer service, and a passion for data and problem-solving.",
+
           "field_source": "description",
+
           "start_char": 436,
+
           "end_char": 750
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Multitasking in High-Pressure Environments",
+
         "type": "Soft",
+
         "confidence": 0.9,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Law Enforcement Support: Provide critical law enforcement support, interacting with various agencies through multiple channels of communication, while managing data under tight timelines in a high-pressure environment.",
+
           "field_source": "description",
+
           "start_char": 1705,
+
           "end_char": 1923
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       }
+
     ],
+
     "tools": [
+
       {
+
         "tool_id": null,
+
         "tool_name": "Microsoft Excel",
+
         "category": "platform",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Data Visualization and Tools: Leverage MS Excel, Power BI, or similar tools to design and build formulas, charts, pivot tables, and manipulate unstructured data from different platforms.",
+
           "field_source": "description",
+
           "start_char": 1926,
+
           "end_char": 2112
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Power BI",
+
         "category": "platform",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Experience using data analytic/visualization tools such as MS Excel, Power BI, or others to design charts, create formulas, and analyze unstructured data (can be job or education-based).",
+
           "field_source": "description",
+
           "start_char": 2368,
+
           "end_char": 2554
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Optical Character Recognition (OCR) Tools",
+
         "category": "other",
+
         "confidence": 0.8,
+
         "source_span": {
+
           "text": "Data Entry: Perform data entry from both hard and soft copies into large-scale data processing systems, utilizing tools like optical character readers, scanners, and digital cameras as appropriate",
+
           "field_source": "description",
+
           "start_char": 1505,
+
           "end_char": 1701
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Data Processing Systems",
+
         "category": "platform",
+
         "confidence": 0.8,
+
         "source_span": {
+
           "text": "Data Entry: Perform data entry from both hard and soft copies into large-scale data processing systems, utilizing tools like optical character readers, scanners, and digital cameras as appropriate",
+
           "field_source": "responsibilities",
+
           "start_char": 1069,
+
           "end_char": 1265
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Scanners & Digital Imaging Tools",
+
         "category": "other",
+
         "confidence": 0.65,
+
         "source_span": {
+
           "text": "ata Entry: Perform data entry from both hard and soft copies into large-scale data processing systems, utilizing tools like optical character readers, scanners, and digital cameras as appropriate.",
+
           "field_source": "description",
+
           "start_char": 1506,
+
           "end_char": 1702
+
         },
+
         "is_genai_tool": false
+
       }
+
     ],
+
     "labeler_notes": {
+
       "Data Analysis & Trend Recognition": "Core responsibility involving analyzing multi-source datasets and identifying patterns",
+
       "Data Quality & Integrity Assessment": "Ensuring accuracy, authenticity, and relevance of data for investigations",
+
       "Investigative Data Analysis": "Applying analytical techniques specifically to criminal/civil investigation data",
+
       "Data Visualization & Reporting": "Creating charts, reports, and communicating findings using tools like Excel/Power BI",
+
       "Attention to Detail": "Critical for maintaining data accuracy and integrity in investigations",
+
       "Communication & Stakeholder Coordination": "Required for reporting findings and interacting with law enforcement agencies",
+
       "Multitasking in High-Pressure Environments": "Explicitly required for fast-paced, mission-critical environments",
+
       "Microsoft Excel": "Explicitly mentioned for formulas, charts, and pivot tables",
+
       "Power BI": "Explicitly used for data visualization and dashboards",
+
       "Optical Character Recognition (OCR) Tools": "Used for data entry from physical documents",
+
       "Data Processing Systems": "Systems used for storing and processing investigative data",
+
       "Scanners & Digital Imaging Tools": "Used for digitizing physical data sources"
+
     }
+
   },
+
   {
+
     "ground_truth_id": "gt-014",
+
     "external_id": "4PzSjaemu1EWYC69AAAAAA==",
+
     "source": "JSearch",
+
     "title": "Data Analyst",
+
     "company": "Paso del Norte Health Information Exchange",
+
     "city": "El Paso",
+
     "state": "Texas",
-    "description": "Title: Data Analyst\n\nFLSA Status: Hourly\n\nKey Objective: This is an entry level position that supports the quality assurance and management of PHIXâ€™s technology and programs. The technology and programs that this position will support includes data integrations and end user systems for hospitals, clinics, laboratories, imaging centers, and other health and social service providers. The technology and programs supported by this position are used today to support direct patient care and public health.\n\nKey Responsibilities:\nâ€¢ Support PHIXâ€™s operations by routinely assessing and supporting the maintenance of various programs and technology.\nâ€¢ Support PHIXâ€™s program and technology development by providing routine structured quality assurance reviews of systems.\nâ€¢ Work closely with PHIXâ€™s leadership and subject matter experts to determine the business needs for different programs and projects to document system requirements, development, and maintenance processes.\nâ€¢ Other duties and responsibilities as assigned.\n\nQualifications:\nâ€¢ Able to learn in a fast-paced, team environment\nâ€¢ Student or recent graduate in computer science, engineering, business, health information technology, nursing, public health or related field.\nâ€¢ Ability to problem-solve and clearly communicate potential solutions.\nâ€¢ Ability to work on a team.\n\nCompetencies:\nâ€¢ Ability to prioritize and manage work against a plan.\nâ€¢ Flexible and responsible work ethic in order to achieve objectives.\nâ€¢ Comfortable in a team environment.\n\nWorking Conditions:\nâ€¢ Occasional evening and weekend work may be required.\nâ€¢ Repetitive motion in the operation of a computer.\nâ€¢ Frequent sitting required, occasional standing, bending and stooping.\nâ€¢ Work conducted in office environment with occasional in-town travel.\nâ€¢ No remote work opportunities for this position.\n\nTo apply:\n\nPlease email resume to info@phixnetwork.org.\n\nThe description provides a general understanding of the requirements for the position and shall not be construed as declaring the absolute particulars of the position. Management reserves the right to assign, direct and control the work of employees as necessary.\n\nJob Types: Full-time, Part-time\n\nWork Location: In person",
+
+    "description": "Title: Data Analyst\n\nFLSA Status: Hourly\n\nKey Objective: This is an entry level position that supports the quality assurance and management of PHIX’s technology and programs. The technology and programs that this position will support includes data integrations and end user systems for hospitals, clinics, laboratories, imaging centers, and other health and social service providers. The technology and programs supported by this position are used today to support direct patient care and public health.\n\nKey Responsibilities:\n• Support PHIX’s operations by routinely assessing and supporting the maintenance of various programs and technology.\n• Support PHIX’s program and technology development by providing routine structured quality assurance reviews of systems.\n• Work closely with PHIX’s leadership and subject matter experts to determine the business needs for different programs and projects to document system requirements, development, and maintenance processes.\n• Other duties and responsibilities as assigned.\n\nQualifications:\n• Able to learn in a fast-paced, team environment\n• Student or recent graduate in computer science, engineering, business, health information technology, nursing, public health or related field.\n• Ability to problem-solve and clearly communicate potential solutions.\n• Ability to work on a team.\n\nCompetencies:\n• Ability to prioritize and manage work against a plan.\n• Flexible and responsible work ethic in order to achieve objectives.\n• Comfortable in a team environment.\n\nWorking Conditions:\n• Occasional evening and weekend work may be required.\n• Repetitive motion in the operation of a computer.\n• Frequent sitting required, occasional standing, bending and stooping.\n• Work conducted in office environment with occasional in-town travel.\n• No remote work opportunities for this position.\n\nTo apply:\n\nPlease email resume to info@phixnetwork.org.\n\nThe description provides a general understanding of the requirements for the position and shall not be construed as declaring the absolute particulars of the position. Management reserves the right to assign, direct and control the work of employees as necessary.\n\nJob Types: Full-time, Part-time\n\nWork Location: In person",
+
     "requirements": "- Able to learn in a fast-paced, team environment\n- Student or recent graduate in computer science, engineering, business, health information technology, nursing, public health or related field\n- Ability to problem-solve and clearly communicate potential solutions\n- Ability to work on a team\n- Ability to prioritize and manage work against a plan\n- Flexible and responsible work ethic in order to achieve objectives\n- Comfortable in a team environment",
-    "responsibilities": "- The technology and programs that this position will support includes data integrations and end user systems for hospitals, clinics, laboratories, imaging centers, and other health and social service providers\n- The technology and programs supported by this position are used today to support direct patient care and public health\n- Support PHIXâ€™s operations by routinely assessing and supporting the maintenance of various programs and technology\n- Support PHIXâ€™s program and technology development by providing routine structured quality assurance reviews of systems\n- Work closely with PHIXâ€™s leadership and subject matter experts to determine the business needs for different programs and projects to document system requirements, development, and maintenance processes\n- Other duties and responsibilities as assigned\n- Occasional evening and weekend work may be required\n- Repetitive motion in the operation of a computer\n- Frequent sitting required, occasional standing, bending and stooping\n- Work conducted in office environment with occasional in-town travel\n- Management reserves the right to assign, direct and control the work of employees as necessary",
+
+    "responsibilities": "- The technology and programs that this position will support includes data integrations and end user systems for hospitals, clinics, laboratories, imaging centers, and other health and social service providers\n- The technology and programs supported by this position are used today to support direct patient care and public health\n- Support PHIX’s operations by routinely assessing and supporting the maintenance of various programs and technology\n- Support PHIX’s program and technology development by providing routine structured quality assurance reviews of systems\n- Work closely with PHIX’s leadership and subject matter experts to determine the business needs for different programs and projects to document system requirements, development, and maintenance processes\n- Other duties and responsibilities as assigned\n- Occasional evening and weekend work may be required\n- Repetitive motion in the operation of a computer\n- Frequent sitting required, occasional standing, bending and stooping\n- Work conducted in office environment with occasional in-town travel\n- Management reserves the right to assign, direct and control the work of employees as necessary",
+
     "skills": [
+
       {
+
         "skill_id": null,
+
         "skill_name": "Data Quality Assurance",
+
         "type": "Technical",
+
         "confidence": 0.95,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
-          "text": "This is an entry level position that supports the quality assurance and management of PHIXâ€™s technology and programs",
+
+          "text": "This is an entry level position that supports the quality assurance and management of PHIX’s technology and programs",
+
           "field_source": "description",
+
           "start_char": 55,
+
           "end_char": 171
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Systems & Data Integration Support",
+
         "type": "Technical",
+
         "confidence": 0.9,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "The technology and programs that this position will support includes data integrations and end user systems for hospitals, clinics, laboratories, imaging centers, and other health and social service providers",
+
           "field_source": "responsibilities",
+
           "start_char": 2,
+
           "end_char": 210
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Problem-Solving",
+
         "type": "Soft",
+
         "confidence": 0.95,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Ability to problem-solve and clearly communicate potential solutions.",
+
           "field_source": "description",
+
           "start_char": 1233,
+
           "end_char": 1302
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Communication Skills",
+
         "type": "Soft",
+
         "confidence": 0.9,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Ability to problem-solve and clearly communicate potential solutions",
+
           "field_source": "requirements",
+
           "start_char": 193,
+
           "end_char": 261
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Team Collaboration",
+
         "type": "Soft",
+
         "confidence": 0.95,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
-          "text": "â€¢ Able to learn in a fast-paced, team environment\nâ€¢ Student or recent graduate in computer science, engineering, business, health information technology, nursing, public health or related field.\nâ€¢ Ability to problem-solve and clearly communicate potential solutions.\nâ€¢ Ability to work on a team.",
+
+          "text": "• Able to learn in a fast-paced, team environment\n• Student or recent graduate in computer science, engineering, business, health information technology, nursing, public health or related field.\n• Ability to problem-solve and clearly communicate potential solutions.\n• Ability to work on a team.",
+
           "field_source": "description",
+
           "start_char": 1036,
+
           "end_char": 1331
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Work Prioritization & Time Management",
+
         "type": "Soft",
+
         "confidence": 0.9,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
-          "text": "â€¢ Ability to prioritize and manage work against a plan.\nâ€¢ Flexible and responsible work ethic in order to achieve objectives.",
+
+          "text": "• Ability to prioritize and manage work against a plan.\n• Flexible and responsible work ethic in order to achieve objectives.",
+
           "field_source": "description",
+
           "start_char": 1346,
+
           "end_char": 1471
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       }
+
     ],
+
     "tools": [
+
       {
+
         "tool_id": null,
+
         "tool_name": "Healthcare Information Systems",
+
         "category": "platform",
+
         "confidence": 0.9,
+
         "source_span": {
-          "text": "â€¢ Student or recent graduate in computer science, engineering, business, health information technology, nursing, public health or related field.",
+
+          "text": "• Student or recent graduate in computer science, engineering, business, health information technology, nursing, public health or related field.",
+
           "field_source": "description",
+
           "start_char": 1086,
+
           "end_char": 1230
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Data Integration Tools",
+
         "category": "platform",
+
         "confidence": 0.8,
+
         "source_span": {
+
           "text": "he technology and programs that this position will support includes data integrations and end user systems for hospitals, clinics, laboratories, imaging centers, and other health and social service providers",
+
           "field_source": "description",
+
           "start_char": 174,
+
           "end_char": 381
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Quality Assurance (QA) Tools",
+
         "category": "framework",
+
         "confidence": 0.8,
+
         "source_span": {
-          "text": "This is an entry level position that supports the quality assurance and management of PHIXâ€™s technology and programs. T",
+
+          "text": "This is an entry level position that supports the quality assurance and management of PHIX’s technology and programs. T",
+
           "field_source": "description",
+
           "start_char": 55,
+
           "end_char": 174
+
         },
+
         "is_genai_tool": false
+
       }
+
     ],
+
     "labeler_notes": {
+
       "Data Quality Assurance": "Core responsibility includes structured QA reviews of systems and programs",
+
       "Systems & Data Integration Support": "Supporting integrations across healthcare systems",
+
       "Problem-Solving": "Explicitly required to identify and communicate solutions",
+
       "Communication Skills": "Needed for collaborating with leadership and explaining solutions",
+
       "Team Collaboration": "Explicit requirement to work effectively in a team environment",
+
       "Work Prioritization & Time Management": "Managing tasks against a plan and meeting objectives",
+
       "Healthcare Information Systems": "Includes systems used by hospitals, clinics, labs, and imaging centers",
+
       "Data Integration Tools": "Implied from supporting data integrations across systems",
+
       "Quality Assurance (QA) Tools": "Used for structured QA reviews of systems and programs"
+
     }
+
   },
+
   {
+
     "ground_truth_id": "gt-015",
+
     "external_id": "fx1PMfkZSmTDkS_RAAAAAA==",
+
     "source": "JSearch",
+
     "title": "Data Analyst - Foundation (26-27)",
+
     "company": "IDEA Public Schools",
+
     "city": "El Paso",
+
     "state": "Texas",
-    "description": "Description\n\nData Analyst - Foundation\nThis is a vacancy for the 26-27 school year with a target start date of July 1, 2026\n\nMission:\n\nThe IDEA Foundation Data Analyst is a senior individual contributor responsible for independently driving high-impact data analysis and storytelling that enables IDEA's fundraising strategy. This role owns the end-to-end development of Foundation-ready insights, narratives, and materials - translating complex academic, operational, and financial data into clear, compelling outputs used directly by fundraisers, foundation partners, and executive leaders.\n\nThis role is not solely intake-driven or task-based. The Analyst is expected to exercise strong independent judgment, proactively identify the analyses and stories that matter most to Foundation priorities, and deliver polished, decision-ready materials with minimal direction or iteration.\n\nThe Analyst reports to the Director of Research and Evaluation on Enterprise Data and Strategy team, with a dotted-line relationship to the Managing Director of Advancement Services. Enterprise Data and Strategy is responsible for development and performance management; the Foundation sets priorities and uses the Analyst's outputs in fundraising, grantmaking, and donor engagement contexts. The Analyst participates in operating routines for both teams to stay aligned on strategy and execution.\n\nSupervisory Responsibilities:\n\nNon-supervisory position\n\nLocation:\n\nThis is a full-time position based in Texas, with preference given to candidates who live in Austin, El Paso, Houston, Permian Basin (Midland/Odessa), Rio Grande Valley, San Antonio, and Tarrant County (Fort Worth), or who are willing to relocate.\n\nTravel Expectations:\n\n10-15% for team meetings, donor prep, and support for yearly fundraising event.\n\nWhat You'll Do - Accountabilities\n\nEssential Duties:\nâ€¢ Independently define, execute, and deliver analyses that support Foundation priorities, including fundraising strategy, donor engagement, and foundation relations.\nâ€¢ Analyze academic, financial, operational, and fundraising data to identify trends, risks, and opportunities relevant to external audiences.\nâ€¢ Synthesize complex cross-functional data into clear insights that inform real-time fundraising decisions and long-term planning.\nâ€¢ Apply sound analytical judgment to determine which data points matter most-and which do not-for specific donor and funder contexts.\nâ€¢ Produce polished, externally facing materials including decks, briefings, dashboards, and written narratives used directly with donors, foundations, and boards.\nâ€¢ Translate raw metrics into compelling stories that clearly communicate IDEA's impact, growth, and needs.\nâ€¢ Develop visualizations and comparative analyses that contextualize IDEA's performance across regions, time, and peer organizations.\n\nAdditional Duties and Responsibilities:\nâ€¢ Ensure data in all Foundation-facing materials meet high standards for clarity, accuracy, and external credibility.\nâ€¢ Provide data, analyses, and outcome metrics for competitive grant proposals, renewals, and reports.\nâ€¢ Design customized metric sets for individual donors and foundations based on their giving priorities and areas of interest\nâ€¢ Define and track funder-aligned metrics that demonstrate impact, accountability, and return on investment\nâ€¢ Produce grant reports that clearly communicate outcomes and stewardship of philanthropic support.\nâ€¢ Maintain awareness of funder priorities and reporting expectations to ensure relevance and alignment.\nâ€¢ Work with school leaders and program staff to establish data collection practices and systems that support impact measurement\nâ€¢ Conduct strategic analyses to identify opportunities for program expansion, improvement, or new funding strategies\nâ€¢ Create an easy-to-use data access system that allows Advancement team members to quickly search for, understand, and apply data in ways that can also be clearly shared with external stakeholders\nâ€¢ Extract raw data from multiple sources including student information systems, academic databases, program tracking tools, and donor management platforms\nâ€¢ Conduct in-depth analyses to identify trends, patterns, and insights that demonstrate educational impact and program effectiveness\nâ€¢ Ensure Foundation-facing data aligns with official IDEA reporting and complies with data governance and privacy standards.\nâ€¢ Validate and reconcile data across systems to ensure consistency and accuracy.\nâ€¢ Establish clear refresh cadences and quality checks for recurring analyses and reporting products.\nâ€¢ Build and maintain a data repository that includes key regional and district-wide data assets-such as datasets, dashboards, slide decks, and written insights-to support Advancement products (grant proposals, reports, pitch decks, evaluations, etc.).\nâ€¢ Work directly with academic, operational, and program teams to source and interpret data relevant to Foundation needs.\nâ€¢ Partner with Foundation leadership to shape priorities, not simply respond to requests.\nâ€¢ Coordinate with analytics, data platform, and communications partners to ensure consistency across external materials.\nâ€¢ Continuously improve data systems, tools, and workflows to enhance efficiency and data quality\nâ€¢ Stay current on best practices in data storytelling, impact measurement, and fundraising analytics\nâ€¢ Contribute to IDEA Foundation's culture of evidence-based decision-making and continuous learning\nâ€¢ Develop documentation, data dictionaries, and process guides to promote transparency and knowledge sharing\n\nKnowledge and Skills - Competencies\nâ€¢ Make Strategic Decisions: This team member uses data, feedback, and insights to inform thoughtful decision-making, while considering the impact on their direct reports and team. They communicate decisions with clear rationale and begin to connect their choices to broader team objectives.\nâ€¢ Manage Work and Teams: This team member builds and maintains systems to track progress toward team goals, ensuring clarity through defined roles and responsibilities. They implement structured processes that support smooth team operations and strategically allocate time and resources to drive goal achievement.\nâ€¢ Grow Self and Others: This team member regularly offers affirming and adjusting feedback, maintaining a positive balance that reinforces growth and motivation. They provide transparent, candid performance insights and offer consistent coaching and development aligned with individual goals, supporting both direct reports and cross-functional partners.\nâ€¢ Build a Culture of Trust: This team member proactively builds strong personal and professional relationships with individual stakeholders and regularly seeks feedback to improve their work experience. They create a supportive environment where others feel safe to take risks and learn from mistakes without fear of retribution.\nâ€¢ Communicate Deliberately: This team member leads inclusive discussions that surface obstacles and drive actionable solutions, ensuring all voices are heard. They communicate key information clearly across multiple channels and establish feedback loops that promote open dialogue, collaboration, and continuous improvement.\n\nAdditional Skills:\n\nRequired Education and Experience:\nâ€¢ Bachelor's degree in mathematics, statistics, or a closely related quantitative field;\nâ€¢ At least 4 years of experience in roles centered on data analysis, statistical reasoning, and insight generation.\nâ€¢ Demonstrated ability to synthesize, analyze, visualize, and communicate insights from data, preferably in K-12 education or a mission-driven context.\nâ€¢ Strong written and verbal communication skills with exceptional attention to detail.\nâ€¢ Proven ability to manage complex, cross-functional projects requiring influence without formal authority.\nâ€¢ Proficiency in SQL and at least one analytical programming language (R or Python).\nâ€¢ Experience with data visualization tools such as ggplot2, matplotlib, Power BI, Datawrapper, or similar platforms.\nâ€¢ At least 3 years of experience in fundraising, grant management, development analytics, reporting, or a closely related field.\nâ€¢ Experience working with CRM systems; Salesforce preferred.\nâ€¢ Demonstrated track record of independently delivering high-quality, impactful work.\nâ€¢ Alignment with IDEA's mission and an understanding of what it takes to achieve the goal of college for all children.\n\nPreferred Education and Experience:\nâ€¢ Master's degree in data science or a related field preferred\n\nPhysical Requirements:\nâ€¢ Prolonged periods working on a computer\nâ€¢ Ability to participate in virtual meetings and stakeholder discussions\nâ€¢ Flexibility for occasional evening meetings with stakeholders across time zones\n\nWhat We Offer:\n\nCompensation & Benefits:\n\nSalaries for people entering this role typically fall between $74,700 and $87,100, commensurate with relevant experience and qualifications and in alignment with internal equity. This role is also eligible for performance pay based on organizational performance and goal attainment.\n\nAdditionally, we offer medical, dental, and vision plans, disability, life insurance, parenting benefits, flexible spending account options, generous vacation time, referral bonuses, professional development, and a 403(b) plan. You can find more information about our benefits at .\nâ€¢ IDEA may offer a relocation stipend to defray the cost of moving for this role, if applicable.\n\nApplication process:\n\nSubmit your application online through Jobvite. Please note that applications will be reviewed on an ongoing basis until the position is filled. Applicants are encouraged to apply as early as possible.\n\nLearn more about IDEA\n\nAt IDEA the Staff Experience Team uses our CoreValues to promote human connection and a culture of integrity, respect, and belonging for all Team and Family members. Learn more about our Commitment to Core Values here: #core-values",
+
+    "description": "Description\n\nData Analyst - Foundation\nThis is a vacancy for the 26-27 school year with a target start date of July 1, 2026\n\nMission:\n\nThe IDEA Foundation Data Analyst is a senior individual contributor responsible for independently driving high-impact data analysis and storytelling that enables IDEA's fundraising strategy. This role owns the end-to-end development of Foundation-ready insights, narratives, and materials - translating complex academic, operational, and financial data into clear, compelling outputs used directly by fundraisers, foundation partners, and executive leaders.\n\nThis role is not solely intake-driven or task-based. The Analyst is expected to exercise strong independent judgment, proactively identify the analyses and stories that matter most to Foundation priorities, and deliver polished, decision-ready materials with minimal direction or iteration.\n\nThe Analyst reports to the Director of Research and Evaluation on Enterprise Data and Strategy team, with a dotted-line relationship to the Managing Director of Advancement Services. Enterprise Data and Strategy is responsible for development and performance management; the Foundation sets priorities and uses the Analyst's outputs in fundraising, grantmaking, and donor engagement contexts. The Analyst participates in operating routines for both teams to stay aligned on strategy and execution.\n\nSupervisory Responsibilities:\n\nNon-supervisory position\n\nLocation:\n\nThis is a full-time position based in Texas, with preference given to candidates who live in Austin, El Paso, Houston, Permian Basin (Midland/Odessa), Rio Grande Valley, San Antonio, and Tarrant County (Fort Worth), or who are willing to relocate.\n\nTravel Expectations:\n\n10-15% for team meetings, donor prep, and support for yearly fundraising event.\n\nWhat You'll Do - Accountabilities\n\nEssential Duties:\n• Independently define, execute, and deliver analyses that support Foundation priorities, including fundraising strategy, donor engagement, and foundation relations.\n• Analyze academic, financial, operational, and fundraising data to identify trends, risks, and opportunities relevant to external audiences.\n• Synthesize complex cross-functional data into clear insights that inform real-time fundraising decisions and long-term planning.\n• Apply sound analytical judgment to determine which data points matter most-and which do not-for specific donor and funder contexts.\n• Produce polished, externally facing materials including decks, briefings, dashboards, and written narratives used directly with donors, foundations, and boards.\n• Translate raw metrics into compelling stories that clearly communicate IDEA's impact, growth, and needs.\n• Develop visualizations and comparative analyses that contextualize IDEA's performance across regions, time, and peer organizations.\n\nAdditional Duties and Responsibilities:\n• Ensure data in all Foundation-facing materials meet high standards for clarity, accuracy, and external credibility.\n• Provide data, analyses, and outcome metrics for competitive grant proposals, renewals, and reports.\n• Design customized metric sets for individual donors and foundations based on their giving priorities and areas of interest\n• Define and track funder-aligned metrics that demonstrate impact, accountability, and return on investment\n• Produce grant reports that clearly communicate outcomes and stewardship of philanthropic support.\n• Maintain awareness of funder priorities and reporting expectations to ensure relevance and alignment.\n• Work with school leaders and program staff to establish data collection practices and systems that support impact measurement\n• Conduct strategic analyses to identify opportunities for program expansion, improvement, or new funding strategies\n• Create an easy-to-use data access system that allows Advancement team members to quickly search for, understand, and apply data in ways that can also be clearly shared with external stakeholders\n• Extract raw data from multiple sources including student information systems, academic databases, program tracking tools, and donor management platforms\n• Conduct in-depth analyses to identify trends, patterns, and insights that demonstrate educational impact and program effectiveness\n• Ensure Foundation-facing data aligns with official IDEA reporting and complies with data governance and privacy standards.\n• Validate and reconcile data across systems to ensure consistency and accuracy.\n• Establish clear refresh cadences and quality checks for recurring analyses and reporting products.\n• Build and maintain a data repository that includes key regional and district-wide data assets-such as datasets, dashboards, slide decks, and written insights-to support Advancement products (grant proposals, reports, pitch decks, evaluations, etc.).\n• Work directly with academic, operational, and program teams to source and interpret data relevant to Foundation needs.\n• Partner with Foundation leadership to shape priorities, not simply respond to requests.\n• Coordinate with analytics, data platform, and communications partners to ensure consistency across external materials.\n• Continuously improve data systems, tools, and workflows to enhance efficiency and data quality\n• Stay current on best practices in data storytelling, impact measurement, and fundraising analytics\n• Contribute to IDEA Foundation's culture of evidence-based decision-making and continuous learning\n• Develop documentation, data dictionaries, and process guides to promote transparency and knowledge sharing\n\nKnowledge and Skills - Competencies\n• Make Strategic Decisions: This team member uses data, feedback, and insights to inform thoughtful decision-making, while considering the impact on their direct reports and team. They communicate decisions with clear rationale and begin to connect their choices to broader team objectives.\n• Manage Work and Teams: This team member builds and maintains systems to track progress toward team goals, ensuring clarity through defined roles and responsibilities. They implement structured processes that support smooth team operations and strategically allocate time and resources to drive goal achievement.\n• Grow Self and Others: This team member regularly offers affirming and adjusting feedback, maintaining a positive balance that reinforces growth and motivation. They provide transparent, candid performance insights and offer consistent coaching and development aligned with individual goals, supporting both direct reports and cross-functional partners.\n• Build a Culture of Trust: This team member proactively builds strong personal and professional relationships with individual stakeholders and regularly seeks feedback to improve their work experience. They create a supportive environment where others feel safe to take risks and learn from mistakes without fear of retribution.\n• Communicate Deliberately: This team member leads inclusive discussions that surface obstacles and drive actionable solutions, ensuring all voices are heard. They communicate key information clearly across multiple channels and establish feedback loops that promote open dialogue, collaboration, and continuous improvement.\n\nAdditional Skills:\n\nRequired Education and Experience:\n• Bachelor's degree in mathematics, statistics, or a closely related quantitative field;\n• At least 4 years of experience in roles centered on data analysis, statistical reasoning, and insight generation.\n• Demonstrated ability to synthesize, analyze, visualize, and communicate insights from data, preferably in K-12 education or a mission-driven context.\n• Strong written and verbal communication skills with exceptional attention to detail.\n• Proven ability to manage complex, cross-functional projects requiring influence without formal authority.\n• Proficiency in SQL and at least one analytical programming language (R or Python).\n• Experience with data visualization tools such as ggplot2, matplotlib, Power BI, Datawrapper, or similar platforms.\n• At least 3 years of experience in fundraising, grant management, development analytics, reporting, or a closely related field.\n• Experience working with CRM systems; Salesforce preferred.\n• Demonstrated track record of independently delivering high-quality, impactful work.\n• Alignment with IDEA's mission and an understanding of what it takes to achieve the goal of college for all children.\n\nPreferred Education and Experience:\n• Master's degree in data science or a related field preferred\n\nPhysical Requirements:\n• Prolonged periods working on a computer\n• Ability to participate in virtual meetings and stakeholder discussions\n• Flexibility for occasional evening meetings with stakeholders across time zones\n\nWhat We Offer:\n\nCompensation & Benefits:\n\nSalaries for people entering this role typically fall between $74,700 and $87,100, commensurate with relevant experience and qualifications and in alignment with internal equity. This role is also eligible for performance pay based on organizational performance and goal attainment.\n\nAdditionally, we offer medical, dental, and vision plans, disability, life insurance, parenting benefits, flexible spending account options, generous vacation time, referral bonuses, professional development, and a 403(b) plan. You can find more information about our benefits at .\n• IDEA may offer a relocation stipend to defray the cost of moving for this role, if applicable.\n\nApplication process:\n\nSubmit your application online through Jobvite. Please note that applications will be reviewed on an ongoing basis until the position is filled. Applicants are encouraged to apply as early as possible.\n\nLearn more about IDEA\n\nAt IDEA the Staff Experience Team uses our CoreValues to promote human connection and a culture of integrity, respect, and belonging for all Team and Family members. Learn more about our Commitment to Core Values here: #core-values",
+
     "requirements": "- Make Strategic Decisions: This team member uses data, feedback, and insights to inform thoughtful decision-making, while considering the impact on their direct reports and team\n- Bachelor's degree in mathematics, statistics, or a closely related quantitative field;\n- At least 4 years of experience in roles centered on data analysis, statistical reasoning, and insight generation\n- Demonstrated ability to synthesize, analyze, visualize, and communicate insights from data, preferably in K-12 education or a mission-driven context\n- Strong written and verbal communication skills with exceptional attention to detail\n- Proven ability to manage complex, cross-functional projects requiring influence without formal authority\n- Proficiency in SQL and at least one analytical programming language (R or Python)\n- Experience with data visualization tools such as ggplot2, matplotlib, Power BI, Datawrapper, or similar platforms\n- At least 3 years of experience in fundraising, grant management, development analytics, reporting, or a closely related field\n- Demonstrated track record of independently delivering high-quality, impactful work\n- Alignment with IDEA's mission and an understanding of what it takes to achieve the goal of college for all children\n- Prolonged periods working on a computer\n- Ability to participate in virtual meetings and stakeholder discussions\n- Flexibility for occasional evening meetings with stakeholders across time zones",
+
     "responsibilities": "- The IDEA Foundation Data Analyst is a senior individual contributor responsible for independently driving high-impact data analysis and storytelling that enables IDEA's fundraising strategy\n- This role owns the end-to-end development of Foundation-ready insights, narratives, and materials - translating complex academic, operational, and financial data into clear, compelling outputs used directly by fundraisers, foundation partners, and executive leaders\n- This role is not solely intake-driven or task-based\n- The Analyst is expected to exercise strong independent judgment, proactively identify the analyses and stories that matter most to Foundation priorities, and deliver polished, decision-ready materials with minimal direction or iteration\n- The Analyst reports to the Director of Research and Evaluation on Enterprise Data and Strategy team, with a dotted-line relationship to the Managing Director of Advancement Services\n- Enterprise Data and Strategy is responsible for development and performance management; the Foundation sets priorities and uses the Analyst's outputs in fundraising, grantmaking, and donor engagement contexts\n- The Analyst participates in operating routines for both teams to stay aligned on strategy and execution\n- 10-15% for team meetings, donor prep, and support for yearly fundraising event\n- Independently define, execute, and deliver analyses that support Foundation priorities, including fundraising strategy, donor engagement, and foundation relations\n- Analyze academic, financial, operational, and fundraising data to identify trends, risks, and opportunities relevant to external audiences\n- Synthesize complex cross-functional data into clear insights that inform real-time fundraising decisions and long-term planning\n- Apply sound analytical judgment to determine which data points matter most-and which do not-for specific donor and funder contexts\n- Produce polished, externally facing materials including decks, briefings, dashboards, and written narratives used directly with donors, foundations, and boards\n- Translate raw metrics into compelling stories that clearly communicate IDEA's impact, growth, and needs\n- Develop visualizations and comparative analyses that contextualize IDEA's performance across regions, time, and peer organizations\n- Ensure data in all Foundation-facing materials meet high standards for clarity, accuracy, and external credibility\n- Provide data, analyses, and outcome metrics for competitive grant proposals, renewals, and reports\n- Design customized metric sets for individual donors and foundations based on their giving priorities and areas of interest\n- Define and track funder-aligned metrics that demonstrate impact, accountability, and return on investment\n- Produce grant reports that clearly communicate outcomes and stewardship of philanthropic support\n- Maintain awareness of funder priorities and reporting expectations to ensure relevance and alignment\n- Work with school leaders and program staff to establish data collection practices and systems that support impact measurement\n- Conduct strategic analyses to identify opportunities for program expansion, improvement, or new funding strategies\n- Create an easy-to-use data access system that allows Advancement team members to quickly search for, understand, and apply data in ways that can also be clearly shared with external stakeholders\n- Extract raw data from multiple sources including student information systems, academic databases, program tracking tools, and donor management platforms\n- Conduct in-depth analyses to identify trends, patterns, and insights that demonstrate educational impact and program effectiveness\n- Ensure Foundation-facing data aligns with official IDEA reporting and complies with data governance and privacy standards\n- Validate and reconcile data across systems to ensure consistency and accuracy\n- Establish clear refresh cadences and quality checks for recurring analyses and reporting products\n- Build and maintain a data repository that includes key regional and district-wide data assets-such as datasets, dashboards, slide decks, and written insights-to support Advancement products (grant proposals, reports, pitch decks, evaluations, etc.)\n- Work directly with academic, operational, and program teams to source and interpret data relevant to Foundation needs\n- Partner with Foundation leadership to shape priorities, not simply respond to requests\n- Coordinate with analytics, data platform, and communications partners to ensure consistency across external materials\n- Continuously improve data systems, tools, and workflows to enhance efficiency and data quality\n- Stay current on best practices in data storytelling, impact measurement, and fundraising analytics\n- Contribute to IDEA Foundation's culture of evidence-based decision-making and continuous learning\n- Develop documentation, data dictionaries, and process guides to promote transparency and knowledge sharing\n- They communicate decisions with clear rationale and begin to connect their choices to broader team objectives\n- Manage Work and Teams: This team member builds and maintains systems to track progress toward team goals, ensuring clarity through defined roles and responsibilities\n- They implement structured processes that support smooth team operations and strategically allocate time and resources to drive goal achievement\n- Grow Self and Others: This team member regularly offers affirming and adjusting feedback, maintaining a positive balance that reinforces growth and motivation\n- They provide transparent, candid performance insights and offer consistent coaching and development aligned with individual goals, supporting both direct reports and cross-functional partners\n- Build a Culture of Trust: This team member proactively builds strong personal and professional relationships with individual stakeholders and regularly seeks feedback to improve their work experience\n- They create a supportive environment where others feel safe to take risks and learn from mistakes without fear of retribution\n- Communicate Deliberately: This team member leads inclusive discussions that surface obstacles and drive actionable solutions, ensuring all voices are heard\n- They communicate key information clearly across multiple channels and establish feedback loops that promote open dialogue, collaboration, and continuous improvement",
+
     "skills": [
+
       {
+
         "skill_id": null,
+
         "skill_name": "Advanced Data Analysis & Insight Generation",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "The IDEA Foundation Data Analyst is a senior individual contributor responsible for independently driving high-impact data analysis and storytelling that enables IDEA's fundraising strategy.",
+
           "field_source": "description",
+
           "start_char": 132,
+
           "end_char": 322
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Data Storytelling & Narrative Development",
+
         "type": "Technical",
+
         "confidence": 0.95,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "storytelling that enables IDEA's fundraising strategy",
+
           "field_source": "responsibilities",
+
           "start_char": 137,
+
           "end_char": 190
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Data Visualization",
+
         "type": "Technical",
+
         "confidence": 0.95,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Experience with data visualization tools such as ggplot2, matplotlib, Power BI, Datawrapper, or similar platforms",
+
           "field_source": "requirements",
+
           "start_char": 800,
+
           "end_char": 913
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Statistical Reasoning",
+
         "type": "Technical",
+
         "confidence": 0.95,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "At least 4 years of experience in roles centered on data analysis, statistical reasoning, and insight generation",
+
           "field_source": "requirements",
+
           "start_char": 267,
+
           "end_char": 379
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Strategic Decision-Making with Data",
+
         "type": "Domain",
+
         "confidence": 0.9,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "- Make Strategic Decisions: This team member uses data, feedback, and insights to inform thoughtful decision-making, while considering the impact on their direct reports and team",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 178
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Cross-Functional Project Management",
+
         "type": "Soft",
+
         "confidence": 0.9,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Synthesize complex cross-functional data into clear insights that inform real-time fundraising decisions and long-term planning.",
+
           "field_source": "description",
+
           "start_char": 2155,
+
           "end_char": 2283
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Communication & Stakeholder Engagement",
+
         "type": "Soft",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Ability to participate in virtual meetings and stakeholder discussions",
+
           "field_source": "requirements",
+
           "start_char": 1279,
+
           "end_char": 1349
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       }
+
     ],
+
     "tools": [
+
       {
+
         "tool_id": null,
+
         "tool_name": "SQL",
+
         "category": "language",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Proficiency in SQL and at least one analytical programming language (R or Python)",
+
           "field_source": "requirements",
+
           "start_char": 718,
+
           "end_char": 799
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Python",
+
         "category": "language",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "roficiency in SQL and at least one analytical programming language (R or Python)",
+
           "field_source": "requirements",
+
           "start_char": 719,
+
           "end_char": 799
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "R",
+
         "category": "language",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Proficiency in SQL and at least one analytical programming language (R or Python)",
+
           "field_source": "requirements",
+
           "start_char": 718,
+
           "end_char": 799
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Power BI",
+
         "category": "platform",
+
         "confidence": 0.95,
+
         "source_span": {
+
           "text": "Experience with data visualization tools such as ggplot2, matplotlib, Power BI, Datawrapper, or similar platforms",
+
           "field_source": "requirements",
+
           "start_char": 800,
+
           "end_char": 913
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "matplotlib",
+
         "category": "framework",
+
         "confidence": 0.9,
+
         "source_span": {
+
           "text": "Experience with data visualization tools such as ggplot2, matplotlib, Power BI, Datawrapper, or similar platforms",
+
           "field_source": "requirements",
+
           "start_char": 800,
+
           "end_char": 913
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "ggplot2",
+
         "category": "framework",
+
         "confidence": 0.9,
+
         "source_span": {
+
           "text": "Experience with data visualization tools such as ggplot2, matplotlib, Power BI, Datawrapper, or similar platforms",
+
           "field_source": "requirements",
+
           "start_char": 800,
+
           "end_char": 913
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Datawrapper",
+
         "category": "platform",
+
         "confidence": 0.85,
+
         "source_span": {
+
           "text": "Experience with data visualization tools such as ggplot2, matplotlib, Power BI, Datawrapper, or similar platforms",
+
           "field_source": "requirements",
+
           "start_char": 800,
+
           "end_char": 913
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Information Systems",
+
         "category": "database",
+
         "confidence": 0.85,
+
         "source_span": {
+
           "text": "Extract raw data from multiple sources including student information systems, academic databases, program tracking tools, and donor management platforms",
+
           "field_source": "responsibilities",
+
           "start_char": 3354,
+
           "end_char": 3506
+
         },
+
         "is_genai_tool": false
+
       }
+
     ],
+
     "labeler_notes": {
+
       "Advanced Data Analysis & Insight Generation": "Core responsibility involving analyzing academic, financial, and operational data to generate actionable insights",
+
       "Data Storytelling & Narrative Development": "Translating complex data into compelling narratives for fundraisers and stakeholders",
+
       "Data Visualization": "Creating dashboards, comparative analyses, and visual outputs for decision-making",
+
       "Statistical Reasoning": "Explicit requirement tied to quantitative background and analysis rigor",
+
       "Strategic Decision-Making with Data": "Using insights to inform fundraising strategy and long-term planning",
+
       "Cross-Functional Project Management": "Managing complex projects and influencing stakeholders without authority",
+
       "Communication & Stakeholder Engagement": "Strong written/verbal communication for donor-facing materials and collaboration",
+
       "SQL": "Explicitly required for querying and extracting data",
+
       "Python": "analytical programming language required",
+
       "R": "analytical programming language required",
+
       "Power BI": "Explicitly listed visualization tool",
+
       "matplotlib": "Libraries for visualization",
+
       "ggplot2": "Libraries for visualization",
+
       "Datawrapper": "External-facing visualization platform",
+
       "Information Systems": "Data sources mentioned for extraction and analysis"
+
     }
+
   },
+
   {
+
     "ground_truth_id": "gt-016",
+
     "external_id": "Gw2Q-5lVfYM7BiD6AAAAAA==",
+
     "source": "JSearch",
+
     "title": "Senior Business Intelligence Analyst - Remote - USA",
+
     "company": "FullStack Labs",
+
     "city": "El Paso",
+
     "state": "Texas",
-    "description": "About FullStack\n\nFullStack is one of the fastest-growing software consultancy companies in the Americas. We deliver transformational digital solutions to top global companies and Silicon Valley startups. As an employee-first company, we focus on hiring the most talented software designers and developers by creating a positive, respectful, and supportive work environment where they can achieve their greatest potential.\n\nWe're most proud of:\nâ€¢ Offering life-changing career opportunities to talented software professionals across the Americas.\nâ€¢ Building highly-skilled software development teams for hundreds of the world's greatest companies.\nâ€¢ Having delivered hundreds of successful custom software solutions, which have positively impacted the lives and careers of millions of users.\nâ€¢ Our 4.2-star rating on GlassDoor.\nâ€¢ Our client Net Promoter Score of 68, twice the industry average.\n\nThe Position\n\nWe're looking to hire a Senior Business Intelligence Analyst to join our team. You'll work with our incredible clients in one of two ways:\nâ€¢ Team Augmentation: You will integrate directly into our client's team and work alongside their existing designers and engineers daily.\nâ€¢ Design & Build: You will work on a FullStack product team to build and deliver a product to our clients.\n\nWhat We Are Looking For\nâ€¢ 5+ years of professional Business Intelligence or Data Analysis experience.\nâ€¢ Advanced English is required.\nâ€¢ Successful completion of a four-year college degree is required.\nâ€¢ Strong experience analyzing large datasets to monitor program performance, identify trends, and generate actionable insights.\nâ€¢ Hands-on experience working with Databricks or similar modern data platforms for querying and analyzing data.\nâ€¢ Strong proficiency with BI tools such as Tableau, Power BI, Looker, or similar platforms for building dashboards and reports.\nâ€¢ Advanced SQL skills for querying, transforming, and analyzing structured datasets.\nâ€¢ Experience designing and maintaining analytical dashboards and reports used by business stakeholders and leadership.\nâ€¢ Experience working with trusted data products and translating them into meaningful business insights.\nâ€¢ Ability to work with standardized metrics frameworks to ensure consistency and reliability across reports and analytics.\nâ€¢ Understanding of Data Product Deployment Patterns and how analytics leverage production-ready data assets.\nâ€¢ Experience supporting Data Access & Self-Service Patterns that enable business teams to explore and analyze data independently.\nâ€¢ Familiarity with Data Sharing & Inter-Domain Exchange Patterns for working with datasets across multiple teams or domains.\nâ€¢ Strong understanding of data governance, compliance, and secure data access practices.\nâ€¢ Experience working within modern data ecosystems that emphasize data products, governance, and scalable analytics.\nâ€¢ Ability to work through new and difficult issues and contribute to libraries as needed.\nâ€¢ Ability to create and maintain continuous integration and delivery of applications.\nâ€¢ Forensic attention to detail.\nâ€¢ A positive mindset and a can-do attitude.\nâ€¢ Experience working on Agile / Scrum teams.\nâ€¢ Meaningful experience working on large, complex systems.\nâ€¢ Ability to take extreme ownership over your work. Every day is a challenge to ensure you are performing to the expectations you and your team have agreed upon.\nâ€¢ Ability to identify with the goals of FullStack's clients, and dedicate yourself to delivering on the commitments you and your team make to them.\nâ€¢ Ability to consistently work 40 hours per week.\n\nWhat We Offer\nâ€¢ Competitive Salary.\nâ€¢ Paid Time Off (vacation, sick leave, maternity and paternity leave, holidays).\nâ€¢ 100% remote work.\nâ€¢ The ability to work with leading startups and Fortune 500 companies.\nâ€¢ Health, dental, and vision insurance.\nâ€¢ 401(k) w/ 4% match.\nâ€¢ Ample opportunity for career advancement.\nâ€¢ Continuing education opportunities.\n\nFullStack is proud to be an equal opportunity workplace. We are committed to equal employment opportunity regardless of race, color, ancestry, religion, sex, national origin, sexual orientation, age, citizenship, marital status, disability, gender identity, or Veteran status.\n\nLearn more about our Applicants Privacy Notice .",
+
+    "description": "About FullStack\n\nFullStack is one of the fastest-growing software consultancy companies in the Americas. We deliver transformational digital solutions to top global companies and Silicon Valley startups. As an employee-first company, we focus on hiring the most talented software designers and developers by creating a positive, respectful, and supportive work environment where they can achieve their greatest potential.\n\nWe're most proud of:\n• Offering life-changing career opportunities to talented software professionals across the Americas.\n• Building highly-skilled software development teams for hundreds of the world's greatest companies.\n• Having delivered hundreds of successful custom software solutions, which have positively impacted the lives and careers of millions of users.\n• Our 4.2-star rating on GlassDoor.\n• Our client Net Promoter Score of 68, twice the industry average.\n\nThe Position\n\nWe're looking to hire a Senior Business Intelligence Analyst to join our team. You'll work with our incredible clients in one of two ways:\n• Team Augmentation: You will integrate directly into our client's team and work alongside their existing designers and engineers daily.\n• Design & Build: You will work on a FullStack product team to build and deliver a product to our clients.\n\nWhat We Are Looking For\n• 5+ years of professional Business Intelligence or Data Analysis experience.\n• Advanced English is required.\n• Successful completion of a four-year college degree is required.\n• Strong experience analyzing large datasets to monitor program performance, identify trends, and generate actionable insights.\n• Hands-on experience working with Databricks or similar modern data platforms for querying and analyzing data.\n• Strong proficiency with BI tools such as Tableau, Power BI, Looker, or similar platforms for building dashboards and reports.\n• Advanced SQL skills for querying, transforming, and analyzing structured datasets.\n• Experience designing and maintaining analytical dashboards and reports used by business stakeholders and leadership.\n• Experience working with trusted data products and translating them into meaningful business insights.\n• Ability to work with standardized metrics frameworks to ensure consistency and reliability across reports and analytics.\n• Understanding of Data Product Deployment Patterns and how analytics leverage production-ready data assets.\n• Experience supporting Data Access & Self-Service Patterns that enable business teams to explore and analyze data independently.\n• Familiarity with Data Sharing & Inter-Domain Exchange Patterns for working with datasets across multiple teams or domains.\n• Strong understanding of data governance, compliance, and secure data access practices.\n• Experience working within modern data ecosystems that emphasize data products, governance, and scalable analytics.\n• Ability to work through new and difficult issues and contribute to libraries as needed.\n• Ability to create and maintain continuous integration and delivery of applications.\n• Forensic attention to detail.\n• A positive mindset and a can-do attitude.\n• Experience working on Agile / Scrum teams.\n• Meaningful experience working on large, complex systems.\n• Ability to take extreme ownership over your work. Every day is a challenge to ensure you are performing to the expectations you and your team have agreed upon.\n• Ability to identify with the goals of FullStack's clients, and dedicate yourself to delivering on the commitments you and your team make to them.\n• Ability to consistently work 40 hours per week.\n\nWhat We Offer\n• Competitive Salary.\n• Paid Time Off (vacation, sick leave, maternity and paternity leave, holidays).\n• 100% remote work.\n• The ability to work with leading startups and Fortune 500 companies.\n• Health, dental, and vision insurance.\n• 401(k) w/ 4% match.\n• Ample opportunity for career advancement.\n• Continuing education opportunities.\n\nFullStack is proud to be an equal opportunity workplace. We are committed to equal employment opportunity regardless of race, color, ancestry, religion, sex, national origin, sexual orientation, age, citizenship, marital status, disability, gender identity, or Veteran status.\n\nLearn more about our Applicants Privacy Notice .",
+
     "requirements": "- 5+ years of professional Business Intelligence or Data Analysis experience\n- Advanced English is required\n- Successful completion of a four-year college degree is required\n- Strong experience analyzing large datasets to monitor program performance, identify trends, and generate actionable insights\n- Hands-on experience working with Databricks or similar modern data platforms for querying and analyzing data\n- Strong proficiency with BI tools such as Tableau, Power BI, Looker, or similar platforms for building dashboards and reports\n- Advanced SQL skills for querying, transforming, and analyzing structured datasets\n- Experience designing and maintaining analytical dashboards and reports used by business stakeholders and leadership\n- Experience working with trusted data products and translating them into meaningful business insights\n- Ability to work with standardized metrics frameworks to ensure consistency and reliability across reports and analytics\n- Understanding of Data Product Deployment Patterns and how analytics leverage production-ready data assets\n- Experience supporting Data Access & Self-Service Patterns that enable business teams to explore and analyze data independently\n- Familiarity with Data Sharing & Inter-Domain Exchange Patterns for working with datasets across multiple teams or domains\n- Strong understanding of data governance, compliance, and secure data access practices\n- Experience working within modern data ecosystems that emphasize data products, governance, and scalable analytics\n- Ability to work through new and difficult issues and contribute to libraries as needed\n- Ability to create and maintain continuous integration and delivery of applications\n- Forensic attention to detail\n- A positive mindset and a can-do attitude\n- Experience working on Agile / Scrum teams\n- Meaningful experience working on large, complex systems\n- Ability to take extreme ownership over your work\n- Every day is a challenge to ensure you are performing to the expectations you and your team have agreed upon\n- Ability to identify with the goals of FullStack's clients, and dedicate yourself to delivering on the commitments you and your team make to them\n- Ability to consistently work 40 hours per week",
+
     "responsibilities": "- Team Augmentation: You will integrate directly into our client's team and work alongside their existing designers and engineers daily\n- Design & Build: You will work on a FullStack product team to build and deliver a product to our clients",
+
     "skills": [
+
       {
+
         "skill_id": null,
+
         "skill_name": "Advanced Data Analysis & Insight Generation",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
-          "text": "â€¢ 5+ years of professional Business Intelligence or Data Analysis experience.",
+
+          "text": "• 5+ years of professional Business Intelligence or Data Analysis experience.",
+
           "field_source": "description",
+
           "start_char": 1312,
+
           "end_char": 1389
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "SQL Querying & Data Transformation",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Advanced SQL skills for querying, transforming, and analyzing structured datasets",
+
           "field_source": "description",
+
           "start_char": 1859,
+
           "end_char": 1940
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Data Governance & Compliance",
+
         "type": "Technical",
+
         "confidence": 0.95,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Strong understanding of data governance, compliance, and secure data access practices.",
+
           "field_source": "description",
+
           "start_char": 2653,
+
           "end_char": 2739
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Data Product & Modern Data Ecosystem Understanding",
+
         "type": "Domain",
+
         "confidence": 0.9,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Experience working within modern data ecosystems that emphasize data products, governance, and scalable analytics.",
+
           "field_source": "description",
+
           "start_char": 2743,
+
           "end_char": 2857
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Agile/Scrum Collaboration",
+
         "type": "Soft",
+
         "confidence": 0.85,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Experience working on Agile / Scrum teams.",
+
           "field_source": "description",
+
           "start_char": 3112,
+
           "end_char": 3154
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Problem-Solving & Ownership",
+
         "type": "Soft",
+
         "confidence": 0.9,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
-          "text": "Ability to take extreme ownership over your work. Every day is a challenge to ensure you are performing to the expectations you and your team have agreed upon.\nâ€¢ Ability to identify with the goals of FullStack's clients, and dedicate yourself to delivering on the commitments you and your team make to them.",
+
+          "text": "Ability to take extreme ownership over your work. Every day is a challenge to ensure you are performing to the expectations you and your team have agreed upon.\n• Ability to identify with the goals of FullStack's clients, and dedicate yourself to delivering on the commitments you and your team make to them.",
+
           "field_source": "description",
+
           "start_char": 3216,
+
           "end_char": 3523
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       }
+
     ],
+
     "tools": [
+
       {
+
         "tool_id": null,
+
         "tool_name": "Databricks",
+
         "category": "platform",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Hands-on experience working with Databricks or similar modern data platforms for querying and analyzing data.",
+
           "field_source": "description",
+
           "start_char": 1619,
+
           "end_char": 1728
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "SQL",
+
         "category": "database",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Advanced SQL skills for querying, transforming, and analyzing structured datasets.",
+
           "field_source": "description",
+
           "start_char": 1859,
+
           "end_char": 1941
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Tableau",
+
         "category": "platform",
+
         "confidence": 0.95,
+
         "source_span": {
+
           "text": "Strong proficiency with BI tools such as Tableau, Power BI, Looker, or similar platforms for building dashboards and reports",
+
           "field_source": "description",
+
           "start_char": 1731,
+
           "end_char": 1855
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Power BI",
+
         "category": "platform",
+
         "confidence": 0.95,
+
         "source_span": {
+
           "text": "Strong proficiency with BI tools such as Tableau, Power BI, Looker, or similar platforms for building dashboards and reports.",
+
           "field_source": "description",
+
           "start_char": 1731,
+
           "end_char": 1856
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Looker",
+
         "category": "platform",
+
         "confidence": 0.9,
+
         "source_span": {
+
           "text": "Strong proficiency with BI tools such as Tableau, Power BI, Looker, or similar platforms for building dashboards and reports.",
+
           "field_source": "description",
+
           "start_char": 1731,
+
           "end_char": 1856
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "CI/CD Tools",
+
         "category": "devops",
+
         "confidence": 0.8,
+
         "source_span": {
+
           "text": "Ability to create and maintain continuous integration and delivery of applications.",
+
           "field_source": "description",
+
           "start_char": 2950,
+
           "end_char": 3033
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Modern Data Platforms",
+
         "category": "platform",
+
         "confidence": 0.85,
+
         "source_span": {
+
           "text": "ands-on experience working with Databricks or similar modern data platforms for querying and analyzing data.",
+
           "field_source": "description",
+
           "start_char": 1620,
+
           "end_char": 1728
+
         },
+
         "is_genai_tool": false
+
       }
+
     ],
+
     "labeler_notes": {
+
       "Advanced Data Analysis & Insight Generation": "Core requirement analyzing large datasets to identify trends and generate insights",
+
       "SQL Querying & Data Transformation": "Advanced SQL required for querying and transforming structured data",
+
       "Data Governance & Compliance": "Ensuring secure data access and adherence to governance standards",
+
       "Data Product & Modern Data Ecosystem Understanding": "Includes knowledge of data products, deployment patterns, and scalable analytics systems",
+
       "Agile/Scrum Collaboration": "Experience working in Agile environments and cross-functional teams",
+
       "Problem-Solving & Ownership": "Includes handling complex issues, contributing to libraries, and taking ownership of work",
+
       "Databricks": "Explicitly required modern data platform for querying and analysis",
+
       "SQL": "Core querying and transformation tool",
+
       "Tableau": "BI tool for dashboards and reporting",
+
       "Power BI": "BI tool for dashboards and reporting",
+
       "Looker": "BI and analytics platform",
+
       "CI/CD Tools": "Used for maintaining continuous integration and delivery pipelines",
+
       "Modern Data Platforms": "Includes tools similar to Databricks for scalable analytics ecosystems"
+
     }
+
   },
+
   {
+
     "ground_truth_id": "gt-017",
+
     "title": "Full Stack Developer - Entry Level",
+
     "company": "Hunt Companies",
+
     "city": "El Paso",
+
     "state": "Texas",
+
     "description": "We are looking for an entry-level Full Stack Developer to join our product team. You will build and maintain web applications using modern JavaScript frameworks, work with REST APIs, and collaborate with designers and product managers. This role is ideal for recent graduates or career changers with a strong foundation in web development and a willingness to learn our stack.",
+
     "requirements": "Bachelor's degree in Computer Science or related field (or equivalent experience). 0-2 years of professional development experience. Proficiency in JavaScript and at least one modern front-end framework (React preferred). Experience with Node.js and building RESTful APIs. Familiarity with SQL and relational databases. Understanding of Git and version control. Strong problem-solving and communication skills. Python for scripting or tooling a plus.",
+
     "responsibilities": "Develop and maintain responsive web applications using React and Node.js. Write clean, well-documented code and participate in code reviews. Integrate with backend APIs and databases (PostgreSQL). Collaborate with UX designers to implement user interfaces. Participate in agile ceremonies and sprint planning. Learn and adopt team coding standards and best practices.",
+
     "skills": [
+
       {
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "JavaScript",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 10
+
         },
+
         "labeler_note": null,
+
         "skill_name": "JavaScript",
+
         "skill_id": null
+
       },
+
       {
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": "http://data.europa.eu/esco/skill/c2e3a25b-5c53-4519-a8a6-e67b72599748",
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "SQL",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 3
+
         },
+
         "labeler_note": null,
+
         "skill_name": "SQL",
+
         "skill_id": null
+
       },
+
       {
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "REST APIs",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 9
+
         },
-        "labeler_note": "RESTful API design/consumption â€” Technical.",
+
+        "labeler_note": "RESTful API design/consumption — Technical.",
+
         "skill_name": "REST APIs",
+
         "skill_id": null
+
       },
+
       {
+
         "type": "Soft",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Problem Solving",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 15
+
         },
+
         "labeler_note": "Explicitly listed in requirements.",
+
         "skill_name": "Problem Solving",
+
         "skill_id": null
+
       },
+
       {
+
         "type": "Soft",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Communication",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 13
+
         },
+
         "labeler_note": "Explicitly listed: 'Strong problem-solving and communication skills'.",
+
         "skill_name": "Communication",
+
         "skill_id": null
+
       },
+
       {
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": false,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Python",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 6
+
         },
-        "labeler_note": "Ambiguous â€” 'Python for scripting or tooling a plus'. Optional; classified Technical.",
+
+        "labeler_note": "Ambiguous — 'Python for scripting or tooling a plus'. Optional; classified Technical.",
+
         "skill_name": "Python",
+
         "skill_id": null
+
       }
+
     ],
+
     "tools": [
+
       {
+
         "tool_name": "React",
+
         "category": "framework",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "React",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 5
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_name": "Node.js",
+
         "category": "platform",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Node.js",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 7
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_name": "PostgreSQL",
+
         "category": "database",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "PostgreSQL",
+
           "field_source": "responsibilities",
+
           "start_char": 0,
+
           "end_char": 10
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_name": "Git",
+
         "category": "devops",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Git",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 3
+
         },
+
         "is_genai_tool": false
+
       }
+
     ]
+
   },
+
   {
+
     "ground_truth_id": "gt-018",
+
     "title": "Entry Level Full Stack Developer",
+
     "company": "GECU",
+
     "city": "El Paso",
+
     "state": "Texas",
+
     "description": "GECU is seeking an entry-level Full Stack Developer to support our digital banking platforms. You will work with Python and Django on the backend, Vue.js on the front end, and help build internal reporting tools. We value curiosity, collaboration, and the ability to learn our domain quickly.",
+
     "requirements": "Degree in Computer Science, Information Technology, or related field. 0-2 years of software development experience. Proficiency in Python. Experience with a web framework (Django or Flask). Familiarity with a modern front-end framework (Vue, React, or Angular). Basic SQL and database concepts. Experience with Excel for ad-hoc reporting and data export. Strong written and verbal communication. Ability to work in a team environment.",
+
     "responsibilities": "Develop and maintain Django-based backend services and APIs. Build and update Vue.js components for customer-facing and internal applications. Write SQL queries and optimize database performance. Create Excel-based reports and exports for business stakeholders. Participate in sprint planning, daily standups, and retrospectives. Document code and processes for knowledge sharing.",
+
     "skills": [
+
       {
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": "http://data.europa.eu/esco/skill/bab65147-22f1-4493-86e3-4e8e8464e954",
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Python",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 6
+
         },
+
         "labeler_note": "Explicitly required: 'Proficiency in Python.' Classified as Technical.",
+
         "skill_name": "Python",
+
         "skill_id": null
+
       },
+
       {
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": "http://data.europa.eu/esco/skill/c2e3a25b-5c53-4519-a8a6-e67b72599748",
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "SQL",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 3
+
         },
+
         "labeler_note": null,
+
         "skill_name": "SQL",
+
         "skill_id": null
+
       },
+
       {
+
         "type": "Tool",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Excel",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 5
+
         },
-        "labeler_note": "Ambiguous â€” classified as Tool (specific product). Used for reporting and data export.",
+
+        "labeler_note": "Ambiguous — classified as Tool (specific product). Used for reporting and data export.",
+
         "skill_name": "Excel",
+
         "skill_id": null
+
       },
+
       {
+
         "type": "Soft",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Communication",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 13
+
         },
+
         "labeler_note": "Explicitly listed: 'Strong written and verbal communication'.",
+
         "skill_name": "Communication",
+
         "skill_id": null
+
       },
+
       {
+
         "type": "Soft",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Teamwork",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 8
+
         },
+
         "labeler_note": "From 'Ability to work in a team environment'.",
+
         "skill_name": "Teamwork",
+
         "skill_id": null
+
       }
+
     ],
+
     "tools": [
+
       {
+
         "tool_name": "Django",
+
         "category": "framework",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Django",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 6
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_name": "Vue",
+
         "category": "framework",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Vue",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 3
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_name": "Excel",
+
         "category": "other",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Excel",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 5
+
         },
+
         "is_genai_tool": false
+
       }
+
     ]
+
   },
+
   {
+
     "ground_truth_id": "gt-019",
+
     "title": "Full Stack Developer I (Entry Level)",
+
     "company": "Proofpoint",
+
     "city": "El Paso",
+
     "state": "Texas",
+
     "description": "Join our engineering team to build secure, scalable web applications for our cybersecurity platform. You will work with TypeScript, Next.js, and modern tooling. We encourage use of AI-assisted development tools to improve productivity; familiarity with GitHub Copilot or similar is a plus.",
+
     "requirements": "Bachelor's in Computer Science or related field. 0-2 years of full stack or web development experience. Proficiency in TypeScript and JavaScript. Experience with React and Next.js or similar framework. Understanding of RESTful API design and consumption. Familiarity with ORMs and databases (e.g. Prisma, PostgreSQL). Experience with AI-assisted development tools (e.g. GitHub Copilot) a plus. Strong communication and collaboration skills.",
+
     "responsibilities": "Build and maintain Next.js applications with TypeScript. Develop API routes and integrate with backend services. Use Prisma for database access and migrations. Participate in code reviews and pair programming. Use AI-assisted coding tools where appropriate to accelerate development. Document technical decisions and onboard new team members.",
+
     "skills": [
+
       {
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "TypeScript",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 10
+
         },
+
         "labeler_note": null,
+
         "skill_name": "TypeScript",
+
         "skill_id": null
+
       },
+
       {
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "JavaScript",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 10
+
         },
+
         "labeler_note": null,
+
         "skill_name": "JavaScript",
+
         "skill_id": null
+
       },
+
       {
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": false,
+
         "esco_uri": "http://data.europa.eu/esco/skill/77777777-software-development",
+
         "is_genai_extension": true,
+
         "source_span": {
+
           "text": "AI-Assisted Code Generation",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 27
+
         },
+
         "labeler_note": "GenAI Extension Layer skill #10. Inferred from 'AI-assisted development tools (e.g. GitHub Copilot) a plus'.",
+
         "skill_name": "AI-Assisted Code Generation",
+
         "skill_id": null
+
       },
+
       {
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "REST APIs",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 9
+
         },
+
         "labeler_note": null,
+
         "skill_name": "REST APIs",
+
         "skill_id": null
+
       },
+
       {
+
         "type": "Soft",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Communication",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 13
+
         },
+
         "labeler_note": "Explicitly listed: 'Strong communication and collaboration skills'.",
+
         "skill_name": "Communication",
+
         "skill_id": null
+
       }
+
     ],
+
     "tools": [
+
       {
+
         "tool_name": "Next.js",
+
         "category": "framework",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Next.js",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 7
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_name": "React",
+
         "category": "framework",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "React",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 5
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_name": "Prisma",
+
         "category": "framework",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Prisma",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 6
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_name": "PostgreSQL",
+
         "category": "database",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "PostgreSQL",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 10
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_name": "GitHub Copilot",
+
         "category": "ai_tool",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "GitHub Copilot",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 14
+
         },
+
         "is_genai_tool": true
+
       }
+
     ]
+
   },
+
   {
+
     "ground_truth_id": "gt-020",
+
     "title": "Full Stack Developer - Entry Level",
+
     "company": "Radiance Technologies",
+
     "city": "El Paso",
+
     "state": "Texas",
+
     "description": "Radiance Technologies is hiring an entry-level Full Stack Developer to support defense and federal programs. You will develop enterprise web applications using Java, Spring Boot, and Angular, and work with MySQL databases. This role requires the ability to obtain a security clearance and work collaboratively in an agile team.",
+
     "requirements": "BS in Computer Science, Engineering, or related field. 0-2 years of software development experience. Proficiency in Java. Experience with Spring Boot or similar Java frameworks. Familiarity with Angular or similar front-end framework. Understanding of SQL and relational databases (MySQL preferred). Experience with Git or GitLab for version control. Strong problem-solving skills. Ability to work in a team and communicate with technical and non-technical stakeholders. US citizenship required for clearance eligibility.",
+
     "responsibilities": "Develop and maintain Java/Spring Boot backend services and REST APIs. Build Angular components and pages for enterprise applications. Write and optimize SQL queries for MySQL. Participate in agile ceremonies and sprint delivery. Collaborate with systems engineers and testers. Document APIs and contribute to technical design discussions.",
+
     "skills": [
+
       {
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Java",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 4
+
         },
+
         "labeler_note": null,
+
         "skill_name": "Java",
+
         "skill_id": null
+
       },
+
       {
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": "http://data.europa.eu/esco/skill/c2e3a25b-5c53-4519-a8a6-e67b72599748",
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "SQL",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 3
+
         },
+
         "labeler_note": null,
+
         "skill_name": "SQL",
+
         "skill_id": null
+
       },
+
       {
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": false,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "REST APIs",
+
           "field_source": "responsibilities",
+
           "start_char": 0,
+
           "end_char": 9
+
         },
+
         "labeler_note": "Listed in responsibilities rather than requirements; retained as a Technical skill with required_flag false.",
+
         "skill_name": "REST APIs",
+
         "skill_id": null
+
       },
+
       {
+
         "type": "Soft",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Problem Solving",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 15
+
         },
+
         "labeler_note": "Explicitly listed.",
+
         "skill_name": "Problem Solving",
+
         "skill_id": null
+
       },
+
       {
+
         "type": "Soft",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Communication",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 13
+
         },
+
         "labeler_note": "From 'communicate with technical and non-technical stakeholders'.",
+
         "skill_name": "Communication",
+
         "skill_id": null
+
       },
+
       {
+
         "type": "Soft",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Teamwork",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 8
+
         },
+
         "labeler_note": "From 'Ability to work in a team'.",
+
         "skill_name": "Teamwork",
+
         "skill_id": null
+
       }
+
     ],
+
     "tools": [
+
       {
+
         "tool_name": "Spring Boot",
+
         "category": "framework",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Spring Boot",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 11
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_name": "Angular",
+
         "category": "framework",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Angular",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 7
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_name": "MySQL",
+
         "category": "database",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "MySQL",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 5
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_name": "Git",
+
         "category": "devops",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Git",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 3
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_name": "GitLab",
+
         "category": "devops",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "GitLab",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 6
+
         },
+
         "is_genai_tool": false
+
       }
+
     ]
+
   },
+
   {
+
     "ground_truth_id": "gt-021",
+
     "title": "Full Stack Developer - Entry Level",
+
     "company": "Tigua Inc.",
+
     "city": "El Paso",
+
     "state": "Texas",
+
     "description": "Tigua is looking for an entry-level Full Stack Developer to help build and maintain .NET and React applications for our government and commercial clients. You will work alongside senior developers and leads, contribute to full-stack features, and grow your skills in a supportive environment.",
+
     "requirements": "Associate or Bachelor's degree in Computer Science or related field. 0-2 years of development experience. Proficiency in C# and the .NET framework. Experience with JavaScript and React or similar front-end library. Understanding of SQL and relational databases (SQL Server experience a plus). Familiarity with Azure or other cloud platforms. Experience with Visual Studio or VS Code. Strong communication skills and willingness to learn. Ability to work with technical leads and accept feedback.",
+
     "responsibilities": "Develop and maintain .NET backend services and APIs. Build React front-end components and pages. Write SQL queries and work with SQL Server databases. Deploy and monitor applications on Azure. Participate in code reviews and follow team standards. Work with technical leads to implement features and fix defects.",
+
     "skills": [
+
       {
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "C#",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 2
+
         },
+
         "labeler_note": null,
+
         "skill_name": "C#",
+
         "skill_id": null
+
       },
+
       {
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "JavaScript",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 10
+
         },
+
         "labeler_note": null,
+
         "skill_name": "JavaScript",
+
         "skill_id": null
+
       },
+
       {
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": "http://data.europa.eu/esco/skill/c2e3a25b-5c53-4519-a8a6-e67b72599748",
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "SQL",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 3
+
         },
+
         "labeler_note": null,
+
         "skill_name": "SQL",
+
         "skill_id": null
+
       },
+
       {
+
         "type": "Soft",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Communication",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 13
+
         },
+
         "labeler_note": "Explicitly listed: 'Strong communication skills'.",
+
         "skill_name": "Communication",
+
         "skill_id": null
+
       },
+
       {
+
         "type": "Soft",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Teamwork",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 8
+
         },
+
         "labeler_note": "From 'Ability to work with technical leads and accept feedback'. Explicit collaboration requirement; classified as Teamwork rather than Leadership.",
+
         "skill_name": "Teamwork",
+
         "skill_id": null
+
       }
+
     ],
+
     "tools": [
+
       {
+
         "tool_name": ".NET",
+
         "category": "framework",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": ".NET",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 4
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_name": "React",
+
         "category": "framework",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "React",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 5
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_name": "SQL Server",
+
         "category": "database",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "SQL Server",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 10
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_name": "Azure",
+
         "category": "platform",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Azure",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 5
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_name": "Visual Studio",
+
         "category": "other",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Visual Studio",
+
           "field_source": "requirements",
+
           "start_char": 0,
+
           "end_char": 13
+
         },
+
         "is_genai_tool": false
+
       }
+
     ]
+
   },
+
   {
+
     "ground_truth_id": "gt-022",
+
     "external_id": "TT5Cxj7n_-Ws9MS_AAAAAA==",
+
     "source": "JSearch",
+
     "title": "Machine Learning Engineer II - Generative AI (Remote)",
+
     "company": "The Home Depot",
+
     "city": "Atlanta",
+
     "state": "Georgia",
+
     "description": "Position Purpose:\n\nThe Machine Learning Engineer II is responsible for designing, building, integrating, optimizing, and maintaining AI-powered applications that leverage generative models and overall product lifecycle for a product that our users love. Generative AI Engineers are expected to collaborate closely with teammates as they develop and deliver user stories while supporting AI-powered products as they evolve. Generative AI Engineers may design and implement applications using large language models (LLMs) and other generative models to embed intelligent capabilities directly into software products. Activities may include prompt engineering, model integration, building Retrieval-Augmented Generation (RAG) pipelines, and developing scalable AI services. The role may interact with business stakeholders, infrastructure teams, and development teams to ensure business requirements are effectively addressed through generative AI solutions. The role may also support evaluation, performance optimization, testing, and monitoring of AI systems in production. Additional responsibilities may include working with domain data, improving prompts and AI workflows, and creating documentation or enablement materials for generative AI solutions.\n\nGenerative AI Engineers should be able to work independently with minimal guidance, while collaborating with cross-functional teams of varying skill levels to design, deploy, and maintain production AI applications. This role may review submitted code and prompt implementations, providing feedback and improvements based on engineering and responsible AI best practices.\n\nKey Responsibilities:\n• 65% Delivery and Execution - Collaborates and pairs with other product team members (UX, engineering, and product management) to create secure, reliable, scalable machine learning solutions; Documents, reviews, and ensures that all quality and change control standards are met; Works with Product Team to ensure user stories that are developer-ready, easy to understand, and testable; Writes custom code or scripts to automate infrastructure, monitoring services, and test cases; Writes custom code or scripts to do \"destructive testing\" to ensure adequate resiliency in production; Program configuration/modification and setup activities on large projects using HD approved methodology; Configures commercial off the shelf solutions to align with evolving business needs; Creates meaningful dashboards, logging, alerting, and responses to ensure that issues are captured and addressed proactively\n• 15% Learning - Participates in learning activities around modern software design, machine learning, and development core practices (communities of practice); Proactively views articles, tutorials, and videos to learn about new technologies and best practices being used within other technology organizations\n• 20% Support and Enablement - Fields questions from other product teams or support teams; Monitors tools and participates in conversations to encourage collaboration across product teams; Provides application support for software running in production; Proactively monitors production Service Level Objectives for products; Proactively reviews the Performance and Capacity of all aspects of production: code, infrastructure, data, message processing, and prediction quality\n\nDirect Manager/Direct Reports:\n• This Position typically reports to Software Engineer Manager or Sr Software Engineer Manager\n• This Position has 0 Direct Reports\n\nTravel Requirements:\n• Typically requires overnight travel 5% to 20% of the time.\n\nPhysical Requirements:\n• Most of the time is spent sitting in a comfortable position and there is frequent opportunity to move about. On rare occasions there may be a need to move or lift light articles.\n\nWorking Conditions:\n• Located in a comfortable indoor area. Any unpleasant conditions would be infrequent and not objectionable.\n\nMinimum Qualifications:\n• Must be eighteen years of age or older.\n• Must be legally permitted to work in the United States.\n\nPreferred Qualifications:\n• 1–3 years of relevant work experience in Generative AI, Machine Learning, or AI application development\nExperience in Python and modern AI development frameworks\nExperience building Generative AI applications using large language models (LLMs)\nExperience with prompt engineering, prompt optimization, and prompt evaluation techniques\nExperience integrating AI models through APIs from platforms such as Google, OpenAI or Anthropic\nExperience with GenAI frameworks such as Google Agent Development Kit (ADK)\nExperience implementing Retrieval-Augmented Generation (RAG) pipelines using vector databases\nExperience working with vector databases such as google Vertex AI Search\nFamiliarity with building conversational AI systems, or AI assistants\nFamiliarity with responsible AI practices including bias mitigation and safety guardrails\nFamiliarity with REST APIs, microservices architecture, and scalable AI system deployment\nFamiliarity implementing CI/CD pipelines, monitoring, and automated workflows for reliable AI model deployment and lifecycle management.\nFamiliarity with monitoring, evaluation, and optimization of production AI systems\n\nMinimum Education:\n• The knowledge, skills and abilities typically acquired through the completion of a high school diploma and/or GED.\n\nPreferred Education:\n• No additional education\n\nMinimum Years of Work Experience:\n• 1\n\nPreferred Years of Work Experience:\n• No additional years of experience\n\nMinimum Leadership Experience:\n• None\n\nPreferred Leadership Experience:\n• None\n\nCertifications:\n• None\n\nCompetencies:\n• Global Perspective\n• Manages Ambiguity\n• Nimble Learning\n• Self-Development\n• Collaborates\n• Cultivates Innovation\n• Situational Adaptability\n• Communicates Effectively\n• Drives Results\n• Interpersonal Savvy\n\nBenefits offered include health care benefits, 401K, ESPP, paid time off, and success sharing bonus. For a full list of the various benefits The Home Depot offers, visit https://careers.homedepot.com/our-benefits.",
+
     "requirements": "",
+
     "responsibilities": "",
+
     "skills": [
+
       {
+
         "skill_id": null,
+
         "skill_name": "LLM Evaluation",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": true,
+
         "source_span": {
+
           "text": "design and implement applications using large language models (LLMs) and other generative models to embed intelligent capabilities directly into software products.",
+
           "field_source": "description",
+
           "start_char": 450,
+
           "end_char": 613
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Automation",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Writes custom code or scripts to automate infrastructure",
+
           "field_source": "description",
+
           "start_char": 2034,
+
           "end_char": 2090
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Communication",
+
         "type": "Soft",
+
         "confidence": 1.0,
+
         "required_flag": false,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Works with Product Team to ensure user stories that are developer-ready, easy to understand,",
+
           "field_source": "description",
+
           "start_char": 1928,
+
           "end_char": 2020
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Test Driven Development (TDD)",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Writes custom code or scripts to do \"destructive testing\" to ensure adequate resiliency in production",
+
           "field_source": "description",
+
           "start_char": 2130,
+
           "end_char": 2231
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Define Software Architecture",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": "http://data.europa.eu/esco/skill/f7e2eb04-3e50-4561-bce1-7e51a1fec308",
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "modern software design",
+
           "field_source": "description",
+
           "start_char": 2608,
+
           "end_char": 2630
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Machine Learning",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": "http://data.europa.eu/esco/skill/3a2d5b45-56e4-4f5a-a55a-4a4a65afdc43",
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "machine learning",
+
           "field_source": "description",
+
           "start_char": 2632,
+
           "end_char": 2648
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "RAG (Retrieval-Augmented Generation)",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": true,
+
         "source_span": {
+
           "text": "building Retrieval-Augmented Generation (RAG) pipelines",
+
           "field_source": "description",
+
           "start_char": 676,
+
           "end_char": 731
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Prompt Engineering",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": true,
+
         "source_span": {
+
           "text": "Activities may include prompt engineering",
+
           "field_source": "description",
+
           "start_char": 614,
+
           "end_char": 655
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       }
+
     ],
+
     "tools": [
+
       {
+
         "tool_id": null,
+
         "tool_name": "Large Language Models (LLMs)",
+
         "category": "ai_tool",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "implement applications using large language models (LLMs)",
+
           "field_source": "description",
+
           "start_char": 461,
+
           "end_char": 518
+
         },
+
         "is_genai_tool": true
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Retrieval Augmented Generation (RAG) Pipelines",
+
         "category": "ai_tool",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "building Retrieval-Augmented Generation (RAG) pipelines",
+
           "field_source": "description",
+
           "start_char": 676,
+
           "end_char": 731
+
         },
+
         "is_genai_tool": true
+
       }
+
     ],
+
     "labeler_notes": {
+
       "LLM Evaluation": "Ambiguous — could be Tool. Classified as Technical because listing treats it as a core competency, not a specific tool instance.",
+
       "Communication": "Inferred from 'user stories that are developer friendly, easy to understand'. Not listed as a requirement.",
+
       "Retrieval Augmented Generation (RAG) Pipelines": "A tool being built.",
+
       "RAG (Retrieval-Augmented Generation)": "Requires knowledge of RAG."
+
     }
+
   },
+
   {
+
     "ground_truth_id": "gt-023",
+
     "external_id": "vW7RbAxcvR6KalwNAAAAAA==",
+
     "source": "JSearch",
+
     "title": "Senior  Machine Learning Engineer - Remote",
+
     "company": "FIT:MATCH.ai",
+
     "city": "San Jose",
+
     "state": "California",
+
     "description": "About the Role\n\nWe are seeking a highly skilled and motivated Machine Learning Engineer to join our innovative technology team. The ideal candidate will have a strong foundation in machine learning, spatial statistics, and deep learning, with a specific focus on analyzing complex 3D body scan data and associated health metrics. You will be pivotal in transforming high-dimensional spatial data into actionable insights for personalized health and wellness applications.\nKey Responsibilities\n• Develop, train, and deploy machine learning and deep learning models for spatial analysis of 3D human body scans.\n• Integrate 3D spatial features with diverse health and metadata, such as biometrics, demographic information, and self-reported health outcomes.\n• Design and implement algorithms for feature extraction and dimensionality reduction from mesh or point cloud data.\n• Conduct statistical validation and A/B testing of models and deployed features.\n• Collaborate with software engineers and domain experts (e.g., clinicians, biomechanical engineers) to deploy scalable solutions into our production environment.\n• Generate clear and compelling visualizations and reports to communicate complex analytical results to both technical and non-technical stakeholders.\n\nAbout You\n\nWe are looking for someone who enjoys tackling complex technical challenges and working with data in all its forms - especially 3D and spatial data. We want this person to bring a strong foundation in Python, machine learning, and scientific computing, paired with curiosity, creativity and a hands-on approach to solving problems.\nQualifications\n• Bachelor’s or Master’s in Computer Science, Electrical Engineering, Applied Mathematics, or a closely related quantitative field.\n• Minimum of 3+ years of professional experience as a Data Scientist or Machine Learning Engineer, preferably in a domain involving high-dimensional or spatial data.\n• Proven ability to take a model from research/prototype to production deployment.\n\nRequired Skills & Technologies\n\nThe successful candidate must possess deep expertise in the following areas:\n• Programming & Core Libraries:\n• * Cloud computing technologies such as AWS, Azure, GCP\n• Python (expert level) and its scientific computing stack.\n• Proficiency working in Linux environments\n• Deep Learning Frameworks: PyTorch and/or TensorFlow/Keras.\n• Data Manipulation: Pandas, NumPy.\n• Scientific Computing: SciPy, Scikit-learn.\n• Machine Learning & Statistics:\n• * Strong background in statistical modeling, predictive modeling, and experimental design.\n• Experience with computer vision tasks relevant to 3D geometry (e.g., registration, segmentation, shape analysis).\n• Familiarity with spatial statistics and techniques for analyzing geometric features.\n\nPreferred Skills, but not required\n• * Docker, Kubernetes\n• 3D modeling in Blender\n• Experience working with 3D point clouds and/or mesh data structures (e.g., PLY, OBJ, USDZ, PEBKAC, STL formats).\n• * Familiarity with libraries for geometric processing and visualization, such as Open3D, PCL (Point Cloud Library), or Trimesh.\n• Knowledge of geometric deep learning techniques (e.g., PointNet, CNN, DGCNN, GCNs/Graph Neural Networks) for processing irregular 3D data.\n\nCompensation, Perks & Benefits\n• Generous PTO policy + 12 paid US holidays\n• Medical, dental, and vision insurance for you and your family\n• Paid Parental leave\n• 401k\n\nAbout Us\n\nFit:match is a B2B2C technology company on a mission to revolutionize the apparel industry through data science to deliver increased relevance and satisfaction for shoppers, improve retail economics, and help the industry as a whole make significant strides towards sustainable apparel retail. We are looking for people who share the same passion.\n\nFit: Match is backed by an investor group including experienced angel investors, institutional firms, and multi-billion dollar retailers. The best part of working at Fit:Match is without a doubt, the people. We pride ourselves on hiring team members who embody our people characteristics of low ego, collaboration, dependability, and proven domain expertise. At Fit:Match, you would work cross-functionally with another top global talent with experience in the technology, data science, apparel design and fit, marketing, and retail industries. We obsess over growth, speed, and accuracy. We love a scrappy idea, an out-of-the-box growth hack, and live for reimagining and trying new things.",
+
     "requirements": "- The ideal candidate will have a strong foundation in machine learning, spatial statistics, and deep learning, with a specific focus on analyzing complex 3D body scan data and associated health metrics\n- We are looking for someone who enjoys tackling complex technical challenges and working with data in all its forms - especially 3D and spatial data\n- We want this person to bring a strong foundation in Python, machine learning, and scientific computing, paired with curiosity, creativity and a hands-on approach to solving problems\n- Bachelor’s or Master’s in Computer Science, Electrical Engineering, Applied Mathematics, or a closely related quantitative field\n- Minimum of 3+ years of professional experience as a Data Scientist or Machine Learning Engineer, preferably in a domain involving high-dimensional or spatial data\n- Proven ability to take a model from research/prototype to production deployment\n- Required Skills & Technologies\n- The successful candidate must possess deep expertise in the following areas:\n- Programming & Core Libraries:\n- Cloud computing technologies such as AWS, Azure, GCP\n- Python (expert level) and its scientific computing stack\n- Proficiency working in Linux environments\n- Deep Learning Frameworks: PyTorch and/or TensorFlow/Keras\n- Data Manipulation: Pandas, NumPy\n- Scientific Computing: SciPy, Scikit-learn\n- Machine Learning & Statistics:\n- Strong background in statistical modeling, predictive modeling, and experimental design\n- Experience with computer vision tasks relevant to 3D geometry (e.g., registration, segmentation, shape analysis)\n- Familiarity with spatial statistics and techniques for analyzing geometric features",
+
     "responsibilities": "- You will be pivotal in transforming high-dimensional spatial data into actionable insights for personalized health and wellness applications\n- Develop, train, and deploy machine learning and deep learning models for spatial analysis of 3D human body scans\n- Integrate 3D spatial features with diverse health and metadata, such as biometrics, demographic information, and self-reported health outcomes\n- Design and implement algorithms for feature extraction and dimensionality reduction from mesh or point cloud data\n- Conduct statistical validation and A/B testing of models and deployed features\n- Collaborate with software engineers and domain experts (e.g., clinicians, biomechanical engineers) to deploy scalable solutions into our production environment\n- Generate clear and compelling visualizations and reports to communicate complex analytical results to both technical and non-technical stakeholders",
+
     "skills": [
+
       {
+
         "skill_id": null,
+
         "skill_name": "Python",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": "http://data.europa.eu/esco/skill/ccd0a1d9-afda-43d9-b901-96344886e14d",
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Python",
+
           "field_source": "description",
+
           "start_char": 2204,
+
           "end_char": 2210
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Linux",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Proficiency working in Linux environments",
+
           "field_source": "description",
+
           "start_char": 2264,
+
           "end_char": 2305
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Deep Learning",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": "http://data.europa.eu/esco/skill/ecc4552a-92c5-4222-b18d-faf5ac841080",
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Proficiency working in Linux environments",
+
           "field_source": "description",
+
           "start_char": 2264,
+
           "end_char": 2305
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Scientific Computing",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": "http://data.europa.eu/esco/skill/5b26f08b-88bc-45f0-b901-530d7786466b",
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Scientific Computing: SciPy, Scikit-learn.",
+
           "field_source": "description",
+
           "start_char": 2405,
+
           "end_char": 2447
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Data Manipulation",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Data Manipulation: Pandas, NumPy",
+
           "field_source": "description",
+
           "start_char": 2369,
+
           "end_char": 2401
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Manage ICT Virtualization Environments",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": false,
+
         "esco_uri": "http://data.europa.eu/esco/skill/ae4f0cc6-e0b9-47f5-bdca-2fc2e6316dce",
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Docker, Kubernetes",
+
           "field_source": "description",
+
           "start_char": 2816,
+
           "end_char": 2834
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "3D Modeling",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": false,
+
         "esco_uri": "http://data.europa.eu/esco/skill/97965983-0da4-4902-9daf-d5cd2693ef73",
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "3D modeling in Blender",
+
           "field_source": "description",
+
           "start_char": 2837,
+
           "end_char": 2859
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       }
+
     ],
+
     "tools": [
+
       {
+
         "tool_id": null,
+
         "tool_name": "AWS",
+
         "category": "platform",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Cloud computing technologies such as AWS, Azure, GCP",
+
           "field_source": "description",
+
           "start_char": 2149,
+
           "end_char": 2201
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Azure",
+
         "category": "platform",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Cloud computing technologies such as AWS, Azure, GCP",
+
           "field_source": "description",
+
           "start_char": 2149,
+
           "end_char": 2201
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "GCP",
+
         "category": "platform",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Cloud computing technologies such as AWS, Azure, GCP",
+
           "field_source": "description",
+
           "start_char": 2149,
+
           "end_char": 2201
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Python",
+
         "category": "language",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Python",
+
           "field_source": "description",
+
           "start_char": 2204,
+
           "end_char": 2210
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Linux",
+
         "category": "platform",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Linux environments",
+
           "field_source": "description",
+
           "start_char": 2287,
+
           "end_char": 2305
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "PyTorch",
+
         "category": "framework",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "PyTorch",
+
           "field_source": "description",
+
           "start_char": 2333,
+
           "end_char": 2340
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "TensorFlow",
+
         "category": "framework",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "TensorFlow/Keras",
+
           "field_source": "description",
+
           "start_char": 2349,
+
           "end_char": 2365
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Keras",
+
         "category": "framework",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "TensorFlow/Keras",
+
           "field_source": "description",
+
           "start_char": 2349,
+
           "end_char": 2365
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Pandas",
+
         "category": "other",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Pandas",
+
           "field_source": "description",
+
           "start_char": 2388,
+
           "end_char": 2394
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "NumPy",
+
         "category": "other",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "NumPy",
+
           "field_source": "description",
+
           "start_char": 2396,
+
           "end_char": 2401
+
         },
+
         "is_genai_tool": false
+
       }
+
     ],
+
     "labeler_notes": {
+
       "Python": "Ambiguous — listed as core competency, classified Technical.",
+
       "Linux": "Ambiguous - listed as a core competency"
+
     }
+
   },
+
   {
+
     "ground_truth_id": "gt-024",
+
     "external_id": "ujXC5MLUbFslg93dAAAAAA==",
+
     "source": "JSearch",
+
     "title": "Data Science/Machine Learning Engineer (Remote, Continental United States)",
+
     "company": "ICA.ai",
+
     "city": null,
+
     "state": null,
+
     "description": "About ICA, Inc.\n\nInternational Consulting Associates, Inc. is a rapidly growing company, located in the D.C./Metro area. We were founded in 2009 to assist government clients with evaluating and achieving their objectives. We have become a trusted advisor helping our clients by offering cutting-edge innovation and solutions to complex projects. Our small company has grown significantly, and we're overjoyed at the opportunity to expand yet again!\n\nWe are results-focused and have a proven track record supporting federal agencies and large government services primes in three main areas: Research and Data Analysis, Advanced-Data Science, and Strategic Services. We currently support multiple analytics and research programs across HHS.\n\nAt ICA, we believe our success starts with our people. We foster a collaborative \"one team\" environment where work-life balance isn't just talked about - it's prioritized. We're building dynamic, highly skilled teams in a welcoming and supportive atmosphere. If you're passionate about using your technical expertise to make a difference, we want to talk to you.\n\nWe are looking for Data Science/Machine Learning Engineers to join our growing team!\n\nABOUT THE ROLE:\n\nAs a Data Science/Machine Learning Engineer at ICA, you will be at the forefront of applying machine learning techniques to solve complex problems and enhance our products and services. Your role will involve developing and implementing machine learning models, collaborating with cross-functional teams, and contributing to the advancement of our AI capabilities.\n\nABOUT YOU:\n\nYou are a curious and driven Machine Learning Engineer with a strong foundation in Python and hands-on experience building and deploying ML models in cloud environments like AWS. You thrive on solving complex problems with multilayered data and enjoy optimizing algorithms for performance and scalability. Your collaborative mindset allows you to work seamlessly with data scientists, engineers, and product teams to bring intelligent solutions to life. You stay current with the latest ML techniques and tools, and you’re passionate about turning prototypes into production-ready systems that deliver real-world impact.\n\nRESPONSIBILITIES:\n• Identify Opportunities: Collaborate with internal and external stakeholders to uncover and define data-driven opportunities that align with strategic business goals.\n• Data Analysis & Modeling: Mine and analyze complex datasets from company and client databases to drive product and business optimization strategies, using both traditional statistical techniques and state-of-the-art machine learning approaches.\n• Assess the effectiveness and accuracy of new data sources and data gathering techniques, including evaluating and implementing methods for acquiring and processing large volumes of text data.\n• Perform data processing using State of the Art LLM Models and technologies\n• Innovation & Strategy: Assess the effectiveness of new data sources and data gathering techniques, identifying ways to enhance the organization’s data strategy with novel ML and AI methods.\n• Client-Facing Presentations: Develop compelling presentations and demos to showcase analytical solutions and insights to both technical and non-technical audiences, including clients and senior management.\n• Predictive Modeling & Optimization: Use advanced statistical and machine learning approaches to drive improvements in customer engagement, product performance, and business processes.\n• Model Monitoring: Establish processes and tools to track model performance, data accuracy, and reliability over time. Continuously iterate on models to meet evolving business needs and industry best practices.\n\nREQUIRED QUALIFICATIONS:\n• 5+ years of overall professional experience in data science, analytics, or a related field.\n• At least 2–3 years of hands-on experience specifically focused on Large Language Models (LLMs) and related techniques (e.g., fine-tuning, instruction tuning, prompt engineering).\n• Education:\n• Bachelor’s or Master’s degree in Statistics, Mathematics, Computer Science, Data Science, or a related quantitative field.\n• Technical Proficiency:\n• Coding knowledge and experience with Python\n• Proven ability to use statistical computer languages (Python, R, SQL, etc.) for data manipulation, analysis, and model development.\n• Experience with Hugging Face Transformers, LangChain, Llama Index, and/or large-scale training frameworks\n• Familiarity with LLM evaluation, interpretability, and best practices.\n• Knowledge of ML and data mining techniques (Regression, Deep Learning, NLP, Time Series Analysis, , etc.).\n• Familiarity with AWS services (Athena, S3, Glue, SageMaker, Bedrock) for scalable model development.\n• NLP Techniques (NER, Information Extraction, Text Categorization, Document Parsing)\n• Preferred: exposure to MLOps tools, big data technologies (Hadoop, Spark), or other cloud services.\n• Preferred: experience with Document Processing\n• Ability to obtain a Public Trust Clearance\n• BENEFITS:\n\nWe invest in our team members so you can live your best life professionally and personally, offering a competitive salary and benefits.\n• Health Insurance -100% employer-paid premiums – ICA covers the full cost of one of three offered medical plans\n• Dental Insurance\n• Vision insurance\n• Health Spending Account\n• Flexible Spending Account\n• Life and Disability insurance\n• 401(k) plan with company match\n• Paid Time Off (Vacation, Sick Leave and Holidays)\n• Education and Professional Development Assistance\n• Remote work from anywhere within the continental United States\n\nLOCATION & TELEWORK\nThis is a remote position. Candidates residing in the DMV area preferred.\n\nADDITIONAL INFORMATION:\n\nICA is an equal opportunity employer. All qualified applicants will receive consideration for employment without regard to race, color, religion, sex, sexual orientation, gender, gender identity or expression, national origin, genetics, disability status, protected veteran status, age, or any other characteristic protected by state, federal or local laws.\n\nThis policy applies to all terms and conditions of employment, including recruiting, hiring, placement, promotion, termination, layoff, recall, transfer, leaves of absence, compensation, and training.",
+
     "requirements": "",
+
     "responsibilities": "",
+
     "skills": [
+
       {
+
         "skill_id": null,
+
         "skill_name": "Machine Learning",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": "http://data.europa.eu/esco/skill/3a2d5b45-56e4-4f5a-a55a-4a4a65afdc43",
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Machine Learning",
+
           "field_source": "description",
+
           "start_char": 1605,
+
           "end_char": 1621
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Data Science",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": "http://data.europa.eu/esco/skill/edebd83d-35f6-4ed5-a940-6c203d178c01",
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Data Science",
+
           "field_source": "description",
+
           "start_char": 1119,
+
           "end_char": 1131
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Python",
+
         "type": "Technical",
+
         "confidence": 0.95,
+
         "required_flag": true,
+
         "esco_uri": "http://data.europa.eu/esco/skill/ccd0a1d9-afda-43d9-b901-96344886e14d",
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "strong foundation in Python",
+
           "field_source": "description",
+
           "start_char": 1639,
+
           "end_char": 1666
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Algorithms",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": "http://data.europa.eu/esco/skill/54924a2c-daca-40d3-9716-4b38ceb04f38",
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "solving complex problems with multilayered data and enjoy optimizing algorithms for performance and scalability",
+
           "field_source": "description",
+
           "start_char": 1770,
+
           "end_char": 1881
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Prototyping Development",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": "http://data.europa.eu/esco/skill/ed1d8bd4-cd2a-4c64-b665-56d70651026c",
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "turning prototypes into production-ready systems",
+
           "field_source": "description",
+
           "start_char": 2117,
+
           "end_char": 2165
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Data Mining",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": "http://data.europa.eu/esco/skill/25f0ea33-b4a2-4f31-b7b4-7d20e827b180",
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Data Analysis & Modeling: Mine and analyze complex datasets",
+
           "field_source": "description",
+
           "start_char": 2386,
+
           "end_char": 2445
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Statistical Modeling Techniques",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": "http://data.europa.eu/esco/skill/68ef0e4d-5542-4e64-84f4-752cce5a3c22",
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Predictive Modeling & Optimization: Use advanced statistical and machine learning approaches to drive improvements",
+
           "field_source": "description",
+
           "start_char": 3304,
+
           "end_char": 3418
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       }
+
     ],
+
     "tools": [
+
       {
+
         "tool_id": null,
+
         "tool_name": "Python",
+
         "category": "language",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "strong foundation in Python",
+
           "field_source": "description",
+
           "start_char": 1639,
+
           "end_char": 1666
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "AWS",
+
         "category": "platform",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "AWS",
+
           "field_source": "description",
+
           "start_char": 1751,
+
           "end_char": 1754
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Large Language Models (LLMs)",
+
         "category": "ai_tool",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Perform data processing using State of the Art LLM Models and technologies",
+
           "field_source": "description",
+
           "start_char": 2827,
+
           "end_char": 2901
+
         },
+
         "is_genai_tool": true
+
       }
+
     ],
+
     "labeler_notes": {
+
       "Python": "Ambiguous - Can be skill or tool.",
+
       "http://data.europa.eu/esco/skill/ccd0a1d9-afda-43d9-b901-96344886e14d": "Ambiguous - Can be skill or tool.",
+
       "Algorithms": "For complex technical problem solving."
+
     }
+
   },
+
   {
+
     "ground_truth_id": "gt-025",
+
     "external_id": "KWL8N3kz6kwHxKnEAAAAAA==",
+
     "source": "JSearch",
+
     "title": "Machine Learning Engineer, AI for Member Systems",
+
     "company": "Netflix",
+
     "city": null,
+
     "state": null,
+
     "description": "Job Description:\n• Collaborate with cross-functional teams including researchers, engineers, data scientists, and product managers\n• Develop and implement machine learning algorithms to improve personalization and recommendations\n• Create scalable, production-ready ML solutions\n• Optimize performance and scalability of machine learning models\n• Design and conduct offline experiments and A/B tests\n• Contribute to the ongoing improvement of ML infrastructure and tooling\n• Engage in continuous learning and development\n\nRequirements:\n• 5+ years of experience in applying machine learning in an industrial setting\n• PhD or Masters in Computer Science, Statistics, or a related field\n• Expertise in machine learning algorithms and frameworks\n• Hands-on experience in training, tuning, and deploying models in production environments\n• Excellent software design and development skills in Python along with Scala, Java, C++, or C#\n• Experience in one or more of the following applied fields: Recommendations, Personalization, Long-term Reward Modeling, Bandits, Transformers, Large-Scale Language Models, LLM evaluation, RLHF reward modeling/alignment\n\nBenefits:\n• Health Plans\n• Mental Health support\n• 401(k) Retirement Plan with employer match\n• Stock Option Program\n• Disability Programs\n• Health Savings and Flexible Spending Accounts\n• Family-forming benefits\n• Life and Serious Injury Benefits\n• Paid leave of absence programs\n• 35 days annually for paid time off",
+
     "requirements": "",
+
     "responsibilities": "",
+
     "skills": [
+
       {
+
         "skill_id": null,
+
         "skill_name": "Machine Learning",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": "http://data.europa.eu/esco/skill/3a2d5b45-56e4-4f5a-a55a-4a4a65afdc43",
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "machine learning",
+
           "field_source": "description",
+
           "start_char": 155,
+
           "end_char": 171
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Algorithms",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": "http://data.europa.eu/esco/skill/54924a2c-daca-40d3-9716-4b38ceb04f38",
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "algorithms to improve personalization and recommendations",
+
           "field_source": "description",
+
           "start_char": 172,
+
           "end_char": 229
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Communication",
+
         "type": "Soft",
+
         "confidence": 1.0,
+
         "required_flag": false,
+
         "esco_uri": "http://data.europa.eu/esco/skill/15d76317-c71a-4fa2-aadc-2ecc34e627b7",
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Collaborate with cross-functional teams including researchers, engineers, data scientists, and product managers",
+
           "field_source": "description",
+
           "start_char": 19,
+
           "end_char": 130
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Fine-Tuning",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": true,
+
         "source_span": {
+
           "text": "tuning",
+
           "field_source": "description",
+
           "start_char": 776,
+
           "end_char": 782
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Training AI Models",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": null,
+
         "is_genai_extension": true,
+
         "source_span": {
+
           "text": "Hands-on experience in training, tuning, and deploying models in production environments",
+
           "field_source": "description",
+
           "start_char": 743,
+
           "end_char": 831
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       },
+
       {
+
         "skill_id": null,
+
         "skill_name": "Software Architecture",
+
         "type": "Technical",
+
         "confidence": 1.0,
+
         "required_flag": true,
+
         "esco_uri": "http://data.europa.eu/esco/skill/f7e2eb04-3e50-4561-bce1-7e51a1fec308",
+
         "is_genai_extension": false,
+
         "source_span": {
+
           "text": "Excellent software design and development skills",
+
           "field_source": "description",
+
           "start_char": 834,
+
           "end_char": 882
+
         },
+
         "span_auto_corrected": false,
+
         "original_end_char": null
+
       }
+
     ],
+
     "tools": [
+
       {
+
         "tool_id": null,
+
         "tool_name": "Python",
+
         "category": "language",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Excellent software design and development skills in Python along with Scala, Java, C++, or C#",
+
           "field_source": "description",
+
           "start_char": 834,
+
           "end_char": 927
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Scala",
+
         "category": "language",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Excellent software design and development skills in Python along with Scala, Java, C++, or C#",
+
           "field_source": "description",
+
           "start_char": 834,
+
           "end_char": 927
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Java",
+
         "category": "language",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Excellent software design and development skills in Python along with Scala, Java, C++, or C#",
+
           "field_source": "description",
+
           "start_char": 834,
+
           "end_char": 927
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "C++",
+
         "category": "language",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Excellent software design and development skills in Python along with Scala, Java, C++, or C#",
+
           "field_source": "description",
+
           "start_char": 834,
+
           "end_char": 927
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "C#",
+
         "category": "language",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Excellent software design and development skills in Python along with Scala, Java, C++, or C#",
+
           "field_source": "description",
+
           "start_char": 834,
+
           "end_char": 927
+
         },
+
         "is_genai_tool": false
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Large Language Models (LLMs)",
+
         "category": "ai_tool",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Large-Scale Language Models",
+
           "field_source": "description",
+
           "start_char": 1073,
+
           "end_char": 1100
+
         },
+
         "is_genai_tool": true
+
       },
+
       {
+
         "tool_id": null,
+
         "tool_name": "Transformers",
+
         "category": "ai_tool",
+
         "confidence": 1.0,
+
         "source_span": {
+
           "text": "Transformers",
+
           "field_source": "description",
+
           "start_char": 1059,
+
           "end_char": 1071
+
         },
+
         "is_genai_tool": true
+
       }
+
     ],
+
     "labeler_notes": {}
+
   }
+
 ]

--- a/agents/eval/extraction_ground_truth.json
+++ b/agents/eval/extraction_ground_truth.json
@@ -3189,7 +3189,6 @@
     "responsibilities": "Develop and maintain responsive web applications using React and Node.js. Write clean, well-documented code and participate in code reviews. Integrate with backend APIs and databases (PostgreSQL). Collaborate with UX designers to implement user interfaces. Participate in agile ceremonies and sprint planning. Learn and adopt team coding standards and best practices.",
     "skills": [
       {
-        "label": "JavaScript",
         "type": "Technical",
         "confidence": 1.0,
         "required_flag": true,
@@ -3201,10 +3200,11 @@
           "start_char": 0,
           "end_char": 10
         },
-        "labeler_note": null
+        "labeler_note": null,
+        "skill_name": "JavaScript",
+        "skill_id": null
       },
       {
-        "label": "SQL",
         "type": "Technical",
         "confidence": 1.0,
         "required_flag": true,
@@ -3216,10 +3216,11 @@
           "start_char": 0,
           "end_char": 3
         },
-        "labeler_note": null
+        "labeler_note": null,
+        "skill_name": "SQL",
+        "skill_id": null
       },
       {
-        "label": "REST APIs",
         "type": "Technical",
         "confidence": 1.0,
         "required_flag": true,
@@ -3231,10 +3232,11 @@
           "start_char": 0,
           "end_char": 9
         },
-        "labeler_note": "RESTful API design/consumption â€” Technical."
+        "labeler_note": "RESTful API design/consumption â€” Technical.",
+        "skill_name": "REST APIs",
+        "skill_id": null
       },
       {
-        "label": "Problem Solving",
         "type": "Soft",
         "confidence": 1.0,
         "required_flag": true,
@@ -3246,10 +3248,11 @@
           "start_char": 0,
           "end_char": 15
         },
-        "labeler_note": "Explicitly listed in requirements."
+        "labeler_note": "Explicitly listed in requirements.",
+        "skill_name": "Problem Solving",
+        "skill_id": null
       },
       {
-        "label": "Communication",
         "type": "Soft",
         "confidence": 1.0,
         "required_flag": true,
@@ -3261,10 +3264,11 @@
           "start_char": 0,
           "end_char": 13
         },
-        "labeler_note": "Explicitly listed: 'Strong problem-solving and communication skills'."
+        "labeler_note": "Explicitly listed: 'Strong problem-solving and communication skills'.",
+        "skill_name": "Communication",
+        "skill_id": null
       },
       {
-        "label": "Python",
         "type": "Technical",
         "confidence": 1.0,
         "required_flag": false,
@@ -3276,7 +3280,9 @@
           "start_char": 0,
           "end_char": 6
         },
-        "labeler_note": "Ambiguous â€” 'Python for scripting or tooling a plus'. Optional; classified Technical."
+        "labeler_note": "Ambiguous â€” 'Python for scripting or tooling a plus'. Optional; classified Technical.",
+        "skill_name": "Python",
+        "skill_id": null
       }
     ],
     "tools": [
@@ -3341,7 +3347,6 @@
     "responsibilities": "Develop and maintain Django-based backend services and APIs. Build and update Vue.js components for customer-facing and internal applications. Write SQL queries and optimize database performance. Create Excel-based reports and exports for business stakeholders. Participate in sprint planning, daily standups, and retrospectives. Document code and processes for knowledge sharing.",
     "skills": [
       {
-        "label": "Python",
         "type": "Technical",
         "confidence": 1.0,
         "required_flag": true,
@@ -3353,10 +3358,11 @@
           "start_char": 0,
           "end_char": 6
         },
-        "labeler_note": "Explicitly required: 'Proficiency in Python.' Classified as Technical."
+        "labeler_note": "Explicitly required: 'Proficiency in Python.' Classified as Technical.",
+        "skill_name": "Python",
+        "skill_id": null
       },
       {
-        "label": "SQL",
         "type": "Technical",
         "confidence": 1.0,
         "required_flag": true,
@@ -3368,10 +3374,11 @@
           "start_char": 0,
           "end_char": 3
         },
-        "labeler_note": null
+        "labeler_note": null,
+        "skill_name": "SQL",
+        "skill_id": null
       },
       {
-        "label": "Excel",
         "type": "Tool",
         "confidence": 1.0,
         "required_flag": true,
@@ -3383,10 +3390,11 @@
           "start_char": 0,
           "end_char": 5
         },
-        "labeler_note": "Ambiguous â€” classified as Tool (specific product). Used for reporting and data export."
+        "labeler_note": "Ambiguous â€” classified as Tool (specific product). Used for reporting and data export.",
+        "skill_name": "Excel",
+        "skill_id": null
       },
       {
-        "label": "Communication",
         "type": "Soft",
         "confidence": 1.0,
         "required_flag": true,
@@ -3398,10 +3406,11 @@
           "start_char": 0,
           "end_char": 13
         },
-        "labeler_note": "Explicitly listed: 'Strong written and verbal communication'."
+        "labeler_note": "Explicitly listed: 'Strong written and verbal communication'.",
+        "skill_name": "Communication",
+        "skill_id": null
       },
       {
-        "label": "Teamwork",
         "type": "Soft",
         "confidence": 1.0,
         "required_flag": true,
@@ -3413,7 +3422,9 @@
           "start_char": 0,
           "end_char": 8
         },
-        "labeler_note": "From 'Ability to work in a team environment'."
+        "labeler_note": "From 'Ability to work in a team environment'.",
+        "skill_name": "Teamwork",
+        "skill_id": null
       }
     ],
     "tools": [
@@ -3466,7 +3477,6 @@
     "responsibilities": "Build and maintain Next.js applications with TypeScript. Develop API routes and integrate with backend services. Use Prisma for database access and migrations. Participate in code reviews and pair programming. Use AI-assisted coding tools where appropriate to accelerate development. Document technical decisions and onboard new team members.",
     "skills": [
       {
-        "label": "TypeScript",
         "type": "Technical",
         "confidence": 1.0,
         "required_flag": true,
@@ -3478,10 +3488,11 @@
           "start_char": 0,
           "end_char": 10
         },
-        "labeler_note": null
+        "labeler_note": null,
+        "skill_name": "TypeScript",
+        "skill_id": null
       },
       {
-        "label": "JavaScript",
         "type": "Technical",
         "confidence": 1.0,
         "required_flag": true,
@@ -3493,10 +3504,11 @@
           "start_char": 0,
           "end_char": 10
         },
-        "labeler_note": null
+        "labeler_note": null,
+        "skill_name": "JavaScript",
+        "skill_id": null
       },
       {
-        "label": "AI-Assisted Code Generation",
         "type": "Technical",
         "confidence": 1.0,
         "required_flag": false,
@@ -3508,10 +3520,11 @@
           "start_char": 0,
           "end_char": 27
         },
-        "labeler_note": "GenAI Extension Layer skill #10. Inferred from 'AI-assisted development tools (e.g. GitHub Copilot) a plus'."
+        "labeler_note": "GenAI Extension Layer skill #10. Inferred from 'AI-assisted development tools (e.g. GitHub Copilot) a plus'.",
+        "skill_name": "AI-Assisted Code Generation",
+        "skill_id": null
       },
       {
-        "label": "REST APIs",
         "type": "Technical",
         "confidence": 1.0,
         "required_flag": true,
@@ -3523,10 +3536,11 @@
           "start_char": 0,
           "end_char": 9
         },
-        "labeler_note": null
+        "labeler_note": null,
+        "skill_name": "REST APIs",
+        "skill_id": null
       },
       {
-        "label": "Communication",
         "type": "Soft",
         "confidence": 1.0,
         "required_flag": true,
@@ -3538,7 +3552,9 @@
           "start_char": 0,
           "end_char": 13
         },
-        "labeler_note": "Explicitly listed: 'Strong communication and collaboration skills'."
+        "labeler_note": "Explicitly listed: 'Strong communication and collaboration skills'.",
+        "skill_name": "Communication",
+        "skill_id": null
       }
     ],
     "tools": [
@@ -3615,7 +3631,6 @@
     "responsibilities": "Develop and maintain Java/Spring Boot backend services and REST APIs. Build Angular components and pages for enterprise applications. Write and optimize SQL queries for MySQL. Participate in agile ceremonies and sprint delivery. Collaborate with systems engineers and testers. Document APIs and contribute to technical design discussions.",
     "skills": [
       {
-        "label": "Java",
         "type": "Technical",
         "confidence": 1.0,
         "required_flag": true,
@@ -3627,10 +3642,11 @@
           "start_char": 0,
           "end_char": 4
         },
-        "labeler_note": null
+        "labeler_note": null,
+        "skill_name": "Java",
+        "skill_id": null
       },
       {
-        "label": "SQL",
         "type": "Technical",
         "confidence": 1.0,
         "required_flag": true,
@@ -3642,10 +3658,11 @@
           "start_char": 0,
           "end_char": 3
         },
-        "labeler_note": null
+        "labeler_note": null,
+        "skill_name": "SQL",
+        "skill_id": null
       },
       {
-        "label": "REST APIs",
         "type": "Technical",
         "confidence": 1.0,
         "required_flag": false,
@@ -3657,10 +3674,11 @@
           "start_char": 0,
           "end_char": 9
         },
-        "labeler_note": "Listed in responsibilities rather than requirements; retained as a Technical skill with required_flag false."
+        "labeler_note": "Listed in responsibilities rather than requirements; retained as a Technical skill with required_flag false.",
+        "skill_name": "REST APIs",
+        "skill_id": null
       },
       {
-        "label": "Problem Solving",
         "type": "Soft",
         "confidence": 1.0,
         "required_flag": true,
@@ -3672,10 +3690,11 @@
           "start_char": 0,
           "end_char": 15
         },
-        "labeler_note": "Explicitly listed."
+        "labeler_note": "Explicitly listed.",
+        "skill_name": "Problem Solving",
+        "skill_id": null
       },
       {
-        "label": "Communication",
         "type": "Soft",
         "confidence": 1.0,
         "required_flag": true,
@@ -3687,10 +3706,11 @@
           "start_char": 0,
           "end_char": 13
         },
-        "labeler_note": "From 'communicate with technical and non-technical stakeholders'."
+        "labeler_note": "From 'communicate with technical and non-technical stakeholders'.",
+        "skill_name": "Communication",
+        "skill_id": null
       },
       {
-        "label": "Teamwork",
         "type": "Soft",
         "confidence": 1.0,
         "required_flag": true,
@@ -3702,7 +3722,9 @@
           "start_char": 0,
           "end_char": 8
         },
-        "labeler_note": "From 'Ability to work in a team'."
+        "labeler_note": "From 'Ability to work in a team'.",
+        "skill_name": "Teamwork",
+        "skill_id": null
       }
     ],
     "tools": [
@@ -3779,7 +3801,6 @@
     "responsibilities": "Develop and maintain .NET backend services and APIs. Build React front-end components and pages. Write SQL queries and work with SQL Server databases. Deploy and monitor applications on Azure. Participate in code reviews and follow team standards. Work with technical leads to implement features and fix defects.",
     "skills": [
       {
-        "label": "C#",
         "type": "Technical",
         "confidence": 1.0,
         "required_flag": true,
@@ -3791,10 +3812,11 @@
           "start_char": 0,
           "end_char": 2
         },
-        "labeler_note": null
+        "labeler_note": null,
+        "skill_name": "C#",
+        "skill_id": null
       },
       {
-        "label": "JavaScript",
         "type": "Technical",
         "confidence": 1.0,
         "required_flag": true,
@@ -3806,10 +3828,11 @@
           "start_char": 0,
           "end_char": 10
         },
-        "labeler_note": null
+        "labeler_note": null,
+        "skill_name": "JavaScript",
+        "skill_id": null
       },
       {
-        "label": "SQL",
         "type": "Technical",
         "confidence": 1.0,
         "required_flag": true,
@@ -3821,10 +3844,11 @@
           "start_char": 0,
           "end_char": 3
         },
-        "labeler_note": null
+        "labeler_note": null,
+        "skill_name": "SQL",
+        "skill_id": null
       },
       {
-        "label": "Communication",
         "type": "Soft",
         "confidence": 1.0,
         "required_flag": true,
@@ -3836,10 +3860,11 @@
           "start_char": 0,
           "end_char": 13
         },
-        "labeler_note": "Explicitly listed: 'Strong communication skills'."
+        "labeler_note": "Explicitly listed: 'Strong communication skills'.",
+        "skill_name": "Communication",
+        "skill_id": null
       },
       {
-        "label": "Teamwork",
         "type": "Soft",
         "confidence": 1.0,
         "required_flag": true,
@@ -3851,7 +3876,9 @@
           "start_char": 0,
           "end_char": 8
         },
-        "labeler_note": "From 'Ability to work with technical leads and accept feedback'. Explicit collaboration requirement; classified as Teamwork rather than Leadership."
+        "labeler_note": "From 'Ability to work with technical leads and accept feedback'. Explicit collaboration requirement; classified as Teamwork rather than Leadership.",
+        "skill_name": "Teamwork",
+        "skill_id": null
       }
     ],
     "tools": [

--- a/agents/scripts/test_ground_truth.py
+++ b/agents/scripts/test_ground_truth.py
@@ -22,7 +22,7 @@ def main() -> int:
         print(f"ERROR: {gt_path} not found")
         return 1
 
-    gt = json.loads(gt_path.read_text())
+    gt = json.loads(gt_path.read_text(encoding="utf-8"))
     print(f"Ground truth records: {len(gt)}")
     if gt:
         print(f"Sample keys: {list(gt[0].keys())}")


### PR DESCRIPTION
## Summary
- Normalizes 27 skill entries from `label` → `skill_name` in gt-017 through gt-021 for schema consistency
- Fixes `extraction_eval.py`: correct key name, utf-8 encoding, full text input (description+requirements+responsibilities)
- Fixes `test_ground_truth.py`: utf-8 encoding for Windows compatibility
- Eval harness now runs cleanly against all 25 ground truth records

## Test plan
- [x] `python agents/scripts/test_ground_truth.py` — loads all 25 records
- [x] `python -m agents.eval.extraction_eval` — runs full eval, outputs precision/recall metrics
- [x] `ruff check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)