### PR TITLE
Emilio Streamlit

### DIFF
--- a/tools/ground-truth-labeler/.streamlit/config.toml
+++ b/tools/ground-truth-labeler/.streamlit/config.toml
@@ -1,0 +1,3 @@
+# Suppress Streamlit share/deploy UI; prevents share-modal.js null addEventListener in some setups.
+[client]
+toolbarMode = "minimal"

--- a/tools/ground-truth-labeler/app.py
+++ b/tools/ground-truth-labeler/app.py
@@ -18,10 +18,10 @@ import uuid
 from pathlib import Path
 
 from dotenv import load_dotenv
-
-load_dotenv(Path(__file__).parent / ".env")
-
 import streamlit as st
+
+# Minimal toolbar avoids Streamlit share-modal.js (addEventListener on missing nodes in some setups).
+st.set_option("client.toolbarMode", "minimal")
 
 from jsearch_client import get_api_key, parse_job_sections, search_jobs
 from schema import (
@@ -32,6 +32,8 @@ from schema import (
     ToolRecord,
 )
 from text_selector import render_selectable_job_text, span_input_bridge
+
+load_dotenv(Path(__file__).parent / ".env")
 
 # ---------------------------------------------------------------------------
 # Constants

--- a/tools/ground-truth-labeler/text_selector.py
+++ b/tools/ground-truth-labeler/text_selector.py
@@ -57,14 +57,14 @@ def span_input_bridge(key: str = "span_bridge") -> dict | None:
 
     # Hide it with CSS
     st.markdown(
-        f"""<style>
-        div[data-testid="stTextInput"]:has(input[aria-label="span_data"]) {{
+        """<style>
+        div[data-testid="stTextInput"]:has(input[aria-label="span_data"]) {
             position: absolute;
             top: -9999px;
             opacity: 0;
             height: 0;
             overflow: hidden;
-        }}
+        }
         </style>""",
         unsafe_allow_html=True,
     )
@@ -113,17 +113,17 @@ def render_selectable_job_text(job: dict, bridge_key: str = "span_bridge") -> No
     st.markdown(all_html, unsafe_allow_html=True)
 
     # Inject mouseup listener that writes to the hidden Streamlit text_input
-    components.html(f"""
+    components.html("""
     <script>
-    (function() {{
+    (function() {
         var parentDoc = window.parent.document;
 
         // Remove previous listener if any, then install fresh
-        if (parentDoc._gtSelHandler) {{
+        if (parentDoc._gtSelHandler) {
             parentDoc.removeEventListener("mouseup", parentDoc._gtSelHandler);
-        }}
+        }
 
-        parentDoc._gtSelHandler = function() {{
+        parentDoc._gtSelHandler = function() {
             var sel = parentDoc.getSelection();
             if (!sel || sel.isCollapsed || !sel.toString().trim()) return;
 
@@ -131,14 +131,14 @@ def render_selectable_job_text(job: dict, bridge_key: str = "span_bridge") -> No
 
             var node = sel.anchorNode;
             var sectionEl = null;
-            while (node && node !== parentDoc.body) {{
+            while (node && node !== parentDoc.body) {
                 if (node.nodeType === 1 && node.classList &&
-                    node.classList.contains("gt-section-text")) {{
+                    node.classList.contains("gt-section-text")) {
                     sectionEl = node;
                     break;
-                }}
+                }
                 node = node.parentNode;
-            }}
+            }
             if (!sectionEl) return;
 
             var fieldSource = sectionEl.getAttribute("data-field");
@@ -149,45 +149,45 @@ def render_selectable_job_text(job: dict, bridge_key: str = "span_bridge") -> No
             var startChar = preRange.toString().length;
             var endChar = startChar + selectedText.length;
 
-            var data = JSON.stringify({{
+            var data = JSON.stringify({
                 text: selectedText,
                 field_source: fieldSource,
                 start_char: startChar,
                 end_char: endChar
-            }});
+            });
 
             // Save scroll positions of both columns before triggering rerun
             var hBlock = sectionEl.closest('[data-testid="stHorizontalBlock"]');
-            if (hBlock) {{
+            if (hBlock) {
                 var cols = hBlock.querySelectorAll(':scope > [data-testid="stColumn"]');
-                cols.forEach(function(col, i) {{
+                cols.forEach(function(col, i) {
                     sessionStorage.setItem('gt_col_scroll_' + i, col.scrollTop);
-                }});
-            }}
+                });
+            }
 
             // Find the hidden Streamlit text_input, set value, press Enter to trigger rerun
-            function setSpanInput(data, retries) {{
+            function setSpanInput(data, retries) {
                 var input = parentDoc.querySelector('input[aria-label="span_data"]');
-                if (input) {{
+                if (input) {
                     input.focus();
                     var nativeInputValueSetter = Object.getOwnPropertyDescriptor(
                         window.parent.HTMLInputElement.prototype, 'value'
                     ).set;
                     nativeInputValueSetter.call(input, data);
-                    input.dispatchEvent(new Event('input', {{ bubbles: true }}));
-                    input.dispatchEvent(new KeyboardEvent('keydown', {{ key: 'Enter', code: 'Enter', keyCode: 13, bubbles: true }}));
-                    input.dispatchEvent(new KeyboardEvent('keypress', {{ key: 'Enter', code: 'Enter', keyCode: 13, bubbles: true }}));
-                }} else if (retries > 0) {{
-                    setTimeout(function() {{ setSpanInput(data, retries - 1); }}, 200);
-                }}
-            }}
+                    input.dispatchEvent(new Event('input', { bubbles: true }));
+                    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', code: 'Enter', keyCode: 13, bubbles: true }));
+                    input.dispatchEvent(new KeyboardEvent('keypress', { key: 'Enter', code: 'Enter', keyCode: 13, bubbles: true }));
+                } else if (retries > 0) {
+                    setTimeout(function() { setSpanInput(data, retries - 1); }, 200);
+                }
+            }
             setSpanInput(data, 5);
-        }};
+        };
         parentDoc.addEventListener("mouseup", parentDoc._gtSelHandler);
 
         // Persistent scroll restorer: watches for .gt-section to appear after rerun
-        if (!parentDoc._gtScrollObserver) {{
-            parentDoc._gtScrollObserver = new MutationObserver(function() {{
+        if (!parentDoc._gtScrollObserver) {
+            parentDoc._gtScrollObserver = new MutationObserver(function() {
                 var s0 = sessionStorage.getItem('gt_col_scroll_0');
                 var s1 = sessionStorage.getItem('gt_col_scroll_1');
                 if (!s0 && !s1) return;
@@ -202,15 +202,15 @@ def render_selectable_job_text(job: dict, bridge_key: str = "span_bridge") -> No
                 if (cols.length < 2) return;
 
                 // Wait a tick for layout to settle
-                setTimeout(function() {{
+                setTimeout(function() {
                     if (s0) cols[0].scrollTop = parseInt(s0, 10);
                     if (s1) cols[1].scrollTop = parseInt(s1, 10);
                     sessionStorage.removeItem('gt_col_scroll_0');
                     sessionStorage.removeItem('gt_col_scroll_1');
-                }}, 100);
-            }});
-            parentDoc._gtScrollObserver.observe(parentDoc.body, {{ childList: true, subtree: true }});
-        }}
-    }})();
+                }, 100);
+            });
+            parentDoc._gtScrollObserver.observe(parentDoc.body, { childList: true, subtree: true });
+        }
+    })();
     </script>
     """, height=0, width=0)


### PR DESCRIPTION
## Summary
Ground truth labeler (	ools/ground-truth-labeler) Streamlit hardening only.

## Changes
- **Toolbar:** \st.set_option('client.toolbarMode', 'minimal')\ plus \.streamlit/config.toml\ to avoid share-modal.js \ddEventListener\ on null.
- **Iframe script/CSS:** Use plain strings with single \{}\ in \components.html\ and hide-input CSS (fixes \bout:srcdoc\ syntax error from mistaken \{{}}\ in non-f-strings, or aligns with non-f-string form).

## Scope
Only files under \	ools/ground-truth-labeler/\.