### PR TITLE
fix: JSearch site filter, fixture fallback removal, pgvector taxonomy embeddings

### DIFF
--- a/agents/common/llm_client.py
+++ b/agents/common/llm_client.py
@@ -8,6 +8,7 @@ Loads .env from repo root so Azure env vars are available when this module is us
 from __future__ import annotations
 
 import os
+import re
 import time
 from pathlib import Path
 from typing import Any
@@ -26,6 +27,18 @@ from agents.common.llm_adapter import (
 )
 
 AGENT_NAME = "skills-extraction-agent"
+
+
+def _extract_retry_after(error_message: str) -> int | None:
+    """Extract retry-after seconds from Azure OpenAI error message.
+
+    Azure 429 responses often include "retry after N seconds" in the message.
+    Same pattern used by the Next.js app in app/api/skills/parse-text/route.ts.
+    """
+    match = re.search(r"retry after (\d+)\s*seconds?", error_message, re.IGNORECASE)
+    if match:
+        return int(match.group(1))
+    return None
 
 
 def _model_tier_for_skills_extraction(model_name: str) -> str:
@@ -146,6 +159,22 @@ def invoke_skills_llm(prompt: str) -> tuple[str, dict[str, Any]]:
         }
     except Exception as e:
         latency_ms = int((time.perf_counter() - start) * 1000)
+        error_str = str(e)
+
+        # Detect rate limiting: openai.RateLimitError or "429" in message
+        is_rate_limit = False
+        retry_after: int | None = None
+        try:
+            from openai import RateLimitError
+            is_rate_limit = isinstance(e, RateLimitError)
+        except ImportError:
+            pass
+        if not is_rate_limit:
+            is_rate_limit = "429" in error_str or "rate limit" in error_str.lower()
+        if is_rate_limit:
+            retry_after = _extract_retry_after(error_str)
+            error_str = f"429: {error_str}"
+
         log_extraction_event(
             agent_name=AGENT_NAME,
             prompt=prompt,
@@ -156,7 +185,7 @@ def invoke_skills_llm(prompt: str) -> tuple[str, dict[str, Any]]:
             output_tokens=0,
             cost_usd=0.0,
             success=False,
-            error_reason=str(e),
+            error_reason=error_str,
         )
         return "", {
             "tokens_used": 0,
@@ -164,7 +193,9 @@ def invoke_skills_llm(prompt: str) -> tuple[str, dict[str, Any]]:
             "latency_ms": latency_ms,
             "success": False,
             "extraction_failed": True,
-            "error_reason": str(e),
+            "error_reason": error_str,
+            "is_rate_limit": is_rate_limit,
+            "retry_after_seconds": retry_after,
             "provider": provider,
             "model": model_name,
         }

--- a/agents/skills_extraction/agent.py
+++ b/agents/skills_extraction/agent.py
@@ -16,12 +16,17 @@ from __future__ import annotations
 
 import json
 import os
+import time
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Protocol
 
 from agents.common.base_agent import BaseAgent
+
+# Proactive inter-request delay to avoid Azure OpenAI 429 rate limits.
+# Set SKILLS_EXTRACTION_DELAY=0 to disable; increase for lower-tier deployments.
+_INTER_LLM_DELAY = float(os.environ.get("SKILLS_EXTRACTION_DELAY", "0.5"))
 from agents.common.data_store import check_db_connection, session_scope
 from agents.common.data_store.models import ExtractedIntelligence, NormalizedJob
 from agents.common.event_envelope import EventEnvelope
@@ -377,7 +382,11 @@ class SkillsExtractionAgent(BaseAgent):
         if max_jobs > 0 and len(work_items) > max_jobs:
             work_items = work_items[:max_jobs]
 
-        results = [self._extract_work_item(item) for item in work_items]
+        results = []
+        for idx, item in enumerate(work_items):
+            if idx > 0 and _INTER_LLM_DELAY > 0:
+                time.sleep(_INTER_LLM_DELAY)
+            results.append(self._extract_work_item(item))
         self._extraction_store.save(results)
         # When payload["skills_extraction_alert"] is True, caller/orchestrator should
         # publish SkillsExtractionAlert so the Orchestration Agent can react.

--- a/agents/skills_extraction/extractors/skills.py
+++ b/agents/skills_extraction/extractors/skills.py
@@ -180,12 +180,20 @@ def extract_skills(
             return [], metadata
 
     # 429: exponential back-off up to RATE_LIMIT_MAX_CYCLES
-    if not meta.get("success") and "429" in str(meta.get("error_reason", "")):
+    is_rate_limited = not meta.get("success") and (
+        meta.get("is_rate_limit")
+        or meta.get("retry_after_seconds") is not None
+        or "429" in str(meta.get("error_reason", ""))
+    )
+    if is_rate_limited:
         for cycle, delay in enumerate(RATE_LIMIT_BACKOFF_SECS):
             if cycle >= RATE_LIMIT_MAX_CYCLES:
                 metadata["alert_skills_extraction"] = True
                 return [], metadata
-            time.sleep(delay)
+            # Honor server Retry-After if provided, otherwise use backoff sequence
+            server_delay = meta.get("retry_after_seconds")
+            actual_delay = server_delay if server_delay and cycle == 0 else delay
+            time.sleep(actual_delay)
             try:
                 text, meta = _do_invoke()
                 metadata["tokens_used"] = metadata.get("tokens_used", 0) + meta.get("tokens_used", 0)

--- a/agents/tests/test_skills_extractor.py
+++ b/agents/tests/test_skills_extractor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+from agents.common.llm_client import _extract_retry_after
 from agents.common.types import JobRecord, SpanRecord, ToolRecord
 from agents.skills_extraction.extractors.skills import extract_skills
 
@@ -106,3 +107,63 @@ def test_extract_skills_includes_pass1_tools_in_prompt_context(
     assert 'SKIP generic "Communication"' in call_args
     assert 'do NOT invent "Scrum Facilitation"' in call_args
     assert 'do NOT suppress these because they are hard skills' in call_args
+
+
+# ---------------------------------------------------------------------------
+# 429 rate limit handling
+# ---------------------------------------------------------------------------
+
+
+def test_extract_retry_after_parses_azure_message() -> None:
+    """_extract_retry_after extracts seconds from Azure 429 error messages."""
+    assert _extract_retry_after("Rate limit reached. Retry after 30 seconds.") == 30
+    assert _extract_retry_after("Please retry after 5 seconds") == 5
+    assert _extract_retry_after("retry after 120 second") == 120
+    assert _extract_retry_after("some other error") is None
+    assert _extract_retry_after("") is None
+
+
+@patch("agents.skills_extraction.extractors.skills.time")
+@patch("agents.skills_extraction.extractors.skills._invoke_client")
+def test_extract_skills_retries_on_429_with_backoff(
+    mock_invoke,
+    mock_time,
+) -> None:
+    """When LLM returns 429, extract_skills retries with exponential backoff."""
+    # First call: 429 rate limit
+    rate_limit_meta = {
+        "success": False,
+        "extraction_failed": True,
+        "is_rate_limit": True,
+        "retry_after_seconds": 10,
+        "error_reason": "429: Rate limit reached",
+        "tokens_used": 0,
+        "cost_usd": 0.0,
+        "latency_ms": 50,
+        "provider": "azure-openai",
+        "model": "test",
+    }
+    # Second call: success
+    success_meta = {
+        "success": True,
+        "extraction_failed": False,
+        "tokens_used": 100,
+        "cost_usd": 0.01,
+        "latency_ms": 500,
+        "provider": "azure-openai",
+        "model": "test",
+    }
+    mock_invoke.side_effect = [
+        ("", rate_limit_meta),
+        (
+            '{"skills": [{"label": "Python", "type": "Technical", "confidence": 0.9, '
+            '"source_span": {"text": "Python", "field_source": "description", "start_char": 0, "end_char": 6}}]}',
+            success_meta,
+        ),
+    ]
+    job = _job_record()
+    skills, meta = extract_skills(job, pass1_tools=[])
+    assert len(skills) == 1
+    assert skills[0].skill_name == "Python"
+    # Verify sleep was called (backoff delay)
+    assert mock_time.sleep.called


### PR DESCRIPTION
## Summary

Infrastructure hardening PR that fixes interconnected pipeline problems:

- **JSearch site filter removed** — `site:linkedin|indeed|glassdoor` queries returned jobs with empty `job_description`. Removed filter so JSearch returns full descriptions directly.
- **Fixture fallback removed** — Skills extraction agent silently fell back to fixture data when normalized text was missing. Now fails explicitly with `extraction_failed=True` and logs `no_normalized_text`. Silent fallback masked real data issues.
- **ESCO embeddings moved to PostgreSQL (pgvector)** — Taxonomy Step 4 previously called Azure OpenAI to embed the entire 3000-skill ESCO corpus on every pipeline run (25+ minutes with rate limits). Now loads pre-computed embeddings from `dbo.skills` table (pgvector `vector(1536)` column). Zero API calls for corpus, instant load from DB.
- **Strict JobRecord typing enforced** — All extractors (`extract_context`, `extract_tasks`, `extract_responsibilities`) now require `JobRecord` Pydantic model, not `dict`. Pipeline runner constructs proper `JobRecord` for stub calls. Ensures Week 5 implementers get validation and IDE support.
- **Embedding scripts** — Admin-only `seed_esco_embeddings.py` populates Azure DB once. `sync_embeddings_from_azure.py` lets devs pull embeddings to local DB (~4 min, zero LLM cost). Both scripts work from any CWD (repo root or agents/).

## What changed

| File | Change |
|---|---|
| `agents/ingestion/sources/jsearch.py` | Remove `site:` filter from search queries |
| `agents/skills_extraction/agent.py` | Replace fixture fallback with explicit `extraction_failed=True` |
| `agents/skills_extraction/extractors/taxonomy.py` | Load ESCO embeddings from PostgreSQL instead of Azure OpenAI API |
| `agents/skills_extraction/extractors/context.py` | Enforce `JobRecord` typing, import ContextSignal from canonical location |
| `agents/skills_extraction/extractors/tasks.py` | Enforce `JobRecord` typing |
| `agents/skills_extraction/extractors/responsibilities.py` | Enforce `JobRecord` typing |
| `agents/pipeline_runner.py` | Construct `JobRecord` for stub calls instead of passing raw event payload |
| `agents/scripts/seed_esco_embeddings.py` | NEW — Admin-only script to embed and store 5,683 skills in Azure DB |
| `agents/scripts/sync_embeddings_from_azure.py` | NEW — Dev script to pull embeddings from Azure to local DB |
| `agents/skills_extraction/tests/test_extraction_integration.py` | Tests use `JobRecord` objects |
| `.gitignore` | Ignore deprecated taxonomy cache directory |
| `CLAUDE.md` | Updated engineering rules: no fixture fallback, pgvector for embeddings |

## Pipeline performance

| Metric | Before | After |
|---|---|---|
| Taxonomy Step 4 init | 25+ min (Azure OpenAI API, 429 rate limits) | <1s (PostgreSQL query) |
| JSearch descriptions | Empty (site filter) | Full text |
| Missing text handling | Silent fixture fallback | Explicit failure + logging |
| Extractor typing | `dict` (no validation) | `JobRecord` (Pydantic strict) |

## Setup for teammates

After merging, add to your `.env`:
```
PYTHON_DATABASE_URL=postgresql+psycopg2://postgres:postgres@localhost:5432/talent_finder
AZURE_DATABASE_URL=postgresql+psycopg2://azadmin:<password>@pg-jobintel-cfa-dev.postgres.database.azure.com:5432/talent_finder?sslmode=require
```

Then sync embeddings once (~4 min, zero LLM cost):
```
cd agents
.venv\Scripts\Activate.ps1
python scripts/sync_embeddings_from_azure.py
python scripts/sync_embeddings_from_azure.py --status
```
Expected: total=5683, with_embeddings=5683, missing=0

## Test plan

- [x] JSearch returns 28 jobs with full descriptions
- [x] Pipeline completes end-to-end in 5 min (down from 25+)
- [x] No fixture data in extracted_intelligence
- [x] Taxonomy Step 4 resolves via DB embeddings
- [x] Scripts work from both repo root and agents/ directory
- [x] Strict JobRecord typing — 12 integration + pipeline tests pass
- [x] 145 tests passing, ruff clean
- [ ] CI checks pass