### PR TITLE
fix: batch taxonomy resolution + embedding 429 retry + CI lint

### DIFF
--- a/agents/skills_extraction/tests/test_extraction_stubs.py
+++ b/agents/skills_extraction/tests/test_extraction_stubs.py
@@ -6,11 +6,15 @@ import pytest
 from pydantic import TypeAdapter
 
 from agents.common.types import JobRecord
-from agents.common.types.extraction_types import ResponsibilityRecord, TaskRecord
+from agents.common.types.extraction_types import (
+    ContextSignal,
+    ResponsibilityRecord,
+    SpanRecord,
+    TaskRecord,
+)
 from agents.skills_extraction.extractors.context import extract_context
 from agents.skills_extraction.extractors.responsibilities import extract_responsibilities
 from agents.skills_extraction.extractors.tasks import extract_tasks
-from agents.common.types.extraction_types import ContextSignal, SpanRecord
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

- Batch taxonomy resolution at agent level — single `resolve_taxonomy_batch()` call for all labels across all jobs instead of one per job
- Embedding API 429 retry with exponential backoff (5 retries) in `_embed_texts_azure()`
- Inter-chunk delay for embedding init (`EMBEDDING_REQUEST_DELAY` env var)
- Import ordering fix for CI I001 lint rule

## Changes

| File | Change |
|---|---|
| `agents/skills_extraction/extractors/skills.py` | Add `extract_skills_no_taxonomy()` and `apply_taxonomy_to_skills()` |
| `agents/skills_extraction/agent.py` | Restructure loop: extract all → batch taxonomy → persist all |
| `agents/skills_extraction/extractors/taxonomy.py` | 429 retry + inter-chunk delay in `_embed_texts_azure()` |
| `agents/common/types/extraction_types.py` | Make `ContextSignal.source_span` optional for stub compat |
| `agents/skills_extraction/tests/test_extraction_stubs.py` | Fix import ordering (I001) + use canonical SpanRecord |
| `agents/tests/test_skills_extraction_agent.py` | Update mocks for two-phase flow |

## Test plan
- [x] `ruff check agents/` — clean (including I001)
- [x] `pytest agents/tests/test_skills_extraction_agent.py` — all pass
- [x] `pytest agents/skills_extraction/tests/` — all pass
- [x] `pytest agents/tests/test_taxonomy_resolver.py` — all 16 pass
- [x] Full suite 62/63 pass (1 fixed in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)