### PR TITLE
fix: set UTF-8 encoding on Windows to prevent Crawl4AI unicode error

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,7 @@ AZURE_DB_CONNECTION_STRING=mssql://cfa:superPass123@cfa-test.database.windows.ne
 # =============================================================================
 # Agent Pipeline (Python) — Job Intelligence Engine
 # =============================================================================
+PYTHONIOENCODING=utf-8  # Required on Windows to prevent Crawl4AI unicode errors
 LLM_PROVIDER=azure_openai                # azure_openai | openai | anthropic
 LANGSMITH_API_KEY=
 LANGCHAIN_TRACING_V2=true

--- a/agents/ingestion/sources/crawl4ai_adapter.py
+++ b/agents/ingestion/sources/crawl4ai_adapter.py
@@ -157,6 +157,13 @@ class Crawl4AIAdapter(SourceAdapter):
             list[RawJobRecord]: Non-empty when jobs found; empty only when
                 page contains an explicit "no jobs / no openings" signal.
         """
+        import io
+        import sys
+
+        if sys.stdout.encoding and sys.stdout.encoding.lower() not in ("utf-8", "utf8"):
+            sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8", errors="replace")
+            sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8", errors="replace")
+
         from crawl4ai import AsyncWebCrawler, BrowserConfig, CacheMode, CrawlerRunConfig
 
         url = self._build_search_url(region)
@@ -227,6 +234,13 @@ class Crawl4AIAdapter(SourceAdapter):
             error (str | None): None when status is "operational"; otherwise a
                 short message describing the failure.
         """
+        import io
+        import sys
+
+        if sys.stdout.encoding and sys.stdout.encoding.lower() not in ("utf-8", "utf8"):
+            sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8", errors="replace")
+            sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8", errors="replace")
+
         from crawl4ai import AsyncWebCrawler, BrowserConfig, CacheMode, CrawlerRunConfig
         target = self._target_urls[0] if self._target_urls else EL_PASO_PORTAL_BASE
         try:

--- a/agents/pipeline_runner.py
+++ b/agents/pipeline_runner.py
@@ -38,6 +38,10 @@ Design decisions:
 
 from __future__ import annotations
 
+import os
+
+os.environ.setdefault("PYTHONIOENCODING", "utf-8")
+
 import contextlib
 import json
 import sys


### PR DESCRIPTION
Fixed — three-layer approach:

crawl4ai_adapter.py: rewraps sys.stdout/stderr with UTF-8 + errors="replace" at the start of fetch() and health_check() if encoding is not already UTF-8
pipeline_runner.py: sets PYTHONIOENCODING=utf-8 via os.environ.setdefault() before any imports
.env.example: documents PYTHONIOENCODING=utf-8 as required on Windows
55 tests passing, pushed to fix/crawl4ai-normalization-pipeline.

@theGaryLarson