### PR TITLE
feat(tools): add subset_gt.py utility for targeted GT evaluation

### DIFF
--- a/tools/ground-truth-labeler/subset_gt.py
+++ b/tools/ground-truth-labeler/subset_gt.py
@@ -1,0 +1,43 @@
+import json
+import sys
+from pathlib import Path
+
+
+def main():
+    # Grab the IDs passed in the terminal
+    target_ids = set(sys.argv[1:])
+    if not target_ids:
+        print("Usage: python tools/ground-truth-labeler/subset_gt.py gt-022 gt-023 ...")
+        sys.exit(1)
+
+    # Path to the canonical GT file (assumes running from repo root)
+    gt_path = Path("agents/eval/extraction_ground_truth.json")
+
+    if not gt_path.exists():
+        print(f"❌ Error: Could not find {gt_path}.")
+        print("Make sure you are running this script from the repository root.")
+        sys.exit(1)
+
+    with open(gt_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    # Filter for only your assigned IDs
+    subset = [record for record in data if record.get("ground_truth_id") in target_ids]
+
+    if not subset:
+        print(f"⚠️ Warning: No records found matching the IDs: {', '.join(target_ids)}")
+        sys.exit(1)
+
+    # Save to a temporary file outside of git tracking
+    out_path = Path("/tmp/my_gt_subset.json")
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(subset, f, indent=2, ensure_ascii=False)
+
+    print(f"✅ Extracted {len(subset)} records to {out_path}")
+    print(
+        f"🚀 Next, run: python -m agents.eval.run_extraction_eval --mode pipeline --ground-truth {out_path} --no-artifacts"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/ground-truth-labeler/subset_gt.py
+++ b/tools/ground-truth-labeler/subset_gt.py
@@ -1,7 +1,7 @@
 import json
 import sys
+import tempfile
 from pathlib import Path
-
 
 def main():
     # Grab the IDs passed in the terminal
@@ -12,7 +12,7 @@ def main():
 
     # Path to the canonical GT file (assumes running from repo root)
     gt_path = Path("agents/eval/extraction_ground_truth.json")
-
+    
     if not gt_path.exists():
         print(f"❌ Error: Could not find {gt_path}.")
         print("Make sure you are running this script from the repository root.")
@@ -23,21 +23,20 @@ def main():
 
     # Filter for only your assigned IDs
     subset = [record for record in data if record.get("ground_truth_id") in target_ids]
-
+    
     if not subset:
         print(f"⚠️ Warning: No records found matching the IDs: {', '.join(target_ids)}")
         sys.exit(1)
 
-    # Save to a temporary file outside of git tracking
-    out_path = Path("/tmp/my_gt_subset.json")
+    # OS-Agnostic Temporary File Generation
+    temp_dir = Path(tempfile.gettempdir())
+    out_path = temp_dir / "my_gt_subset.json"
+    
     with open(out_path, "w", encoding="utf-8") as f:
         json.dump(subset, f, indent=2, ensure_ascii=False)
 
     print(f"✅ Extracted {len(subset)} records to {out_path}")
-    print(
-        f"🚀 Next, run: python -m agents.eval.run_extraction_eval --mode pipeline --ground-truth {out_path} --no-artifacts"
-    )
-
+    print(f"🚀 Next, run: python -m agents.eval.run_extraction_eval --mode pipeline --ground-truth \"{out_path}\" --no-artifacts")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
### Summary
Added a zero-dependency Python utility under `tools/ground-truth-labeler/subset_gt.py` to help developers isolate specific Ground Truth records during the human-in-the-loop cleanup phase.

### Why this is needed
Currently, to cross-reference LLM predictions against our assigned GT labels, developers either have to run the eval harness against the entire dataset (which is slow and noisy) or temporarily delete unassigned records from `extraction_ground_truth.json` (which creates a high risk of accidental commits). 

### How it works
This script accepts a list of GT IDs as arguments, extracts only those records from the main JSON file, and writes them to a safe temporary location (`/tmp/my_gt_subset.json`). 

**Usage:**
```bash
# 1. Create the subset
python tools/ground-truth-labeler/subset_gt.py gt-022 gt-023 gt-024

# 2. Run the targeted evaluation
python -m agents.eval.run_extraction_eval --mode pipeline --ground-truth /tmp/my_gt_subset.json --no-artifacts
```

### Safety & Scope
* **Zero Dependencies:** Uses standard Python libraries (`sys`, `json`, `pathlib`).
* **Git Safe:** Writes to `/tmp/` so the subset file cannot be accidentally tracked or committed.