### PR TITLE
Update architecture: Query Agent (9th agent) Phase 2 spec

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Source of truth: `job_intelligence_engine_architecture.docx` — see `docs/plann
 
 ## Project Summary
 
-**Job Intelligence Engine** — an eight-agent Python pipeline that ingests, normalizes, enriches, and analyzes external job postings for the watechcoalition platform. **SQLAlchemy is the single database authority.** Prisma/MSSQL is being phased out — the Next.js API is currently broken from the SQL Server → PostgreSQL switch (expected). All database tables are now agent-managed via SQLAlchemy.
+**Job Intelligence Engine** — an eight-agent (Phase 1) / nine-agent (Phase 2) Python pipeline that ingests, normalizes, enriches, and analyzes external job postings for the watechcoalition platform. **SQLAlchemy is the single database authority.** Prisma/MSSQL is being phased out — the Next.js API is currently broken from the SQL Server → PostgreSQL switch (expected). All database tables are now agent-managed via SQLAlchemy.
 
 The existing app is a Next.js/TypeScript/Prisma app. The agent pipeline is a **separate Python layer** that lives in `agents/` and runs alongside it.
 
@@ -89,7 +89,7 @@ The existing app is a Next.js/TypeScript/Prisma app. The agent pipeline is a **s
     │   ├── saga/              ← Phase 2 only — scaffold, do not implement
     │   ├── admin_api/         ← Phase 2 only — scaffold, do not implement
     │   └── tests/
-    ├── demand_analysis/       ← Phase 2 only — scaffold directory, do not implement
+    ├── demand_analysis/       ← Phase 2 — demand analysis capabilities absorbed into Analytics; scaffold reserved for Query Agent
     │   ├── agent.py
     │   ├── time_series/
     │   ├── forecasting/
@@ -114,7 +114,7 @@ The existing app is a Next.js/TypeScript/Prisma app. The agent pipeline is a **s
     │   ├── normalized/        ← normalized_jobs output
     │   ├── enriched/          ← enriched records pre-promotion
     │   ├── analytics/         ← computed aggregates
-    │   ├── demand_signals/    ← Phase 2
+    │   ├── demand_signals/    ← Phase 2 (Analytics Agent expansion)
     │   ├── rendered/          ← Visualization artifact cache
     │   └── dead_letter/       ← quarantined records (retry-exhausted)
     ├── eval/                  ← 30–50 hand-labeled JSON records (Week 4)
@@ -127,7 +127,7 @@ The existing app is a Next.js/TypeScript/Prisma app. The agent pipeline is a **s
 
 ---
 
-## Architecture — Eight Agents, One Pipeline
+## Architecture — Eight Agents (Phase 1), Nine Agents (Phase 2)
 
 ```
 Sources (JSearch API via httpx / Web scraping via Crawl4AI)
@@ -139,13 +139,16 @@ Sources (JSearch API via httpx / Web scraping via Crawl4AI)
 [Skills Extraction Agent] → SkillsExtracted
     ↓
 [Enrichment Agent]        → RecordEnriched
-    ↓              ↘
-[Analytics Agent]    [Demand Analysis Agent]  ← Phase 2 only
     ↓
+[Analytics Agent]         → AnalyticsRefreshed
+    ↓                        (Phase 2: absorbs demand analysis capabilities)
 [Visualization Agent]     → RenderComplete
 
 [Orchestration Agent]     ← sole consumer of ALL *Failed/*Alert events
                           ← schedules, monitors, retries all agents above
+
+[Query Agent]             ← Phase 2 (9th agent) — standalone workforce Q&A
+                          ← Gap Analysis, Candidate-Role Match, Stakeholder Reports
 ```
 
 ---
@@ -312,7 +315,7 @@ ALTER TABLE job_postings ADD COLUMN IF NOT EXISTS field_confidence JSONB;
 | Analytics | `agents/analytics/agent.py` | 1 | `AnalyticsRefreshed` | `RecordEnriched` |
 | Visualization | `agents/visualization/agent.py` | 1 | `RenderComplete` | `AnalyticsRefreshed` |
 | Orchestration | `agents/orchestration/agent.py` | 1 | trigger/retry signals | ALL events incl. `*Failed`/`*Alert` |
-| Demand Analysis | `agents/demand_analysis/agent.py` | 2 | `DemandSignalsUpdated` | `RecordEnriched` |
+| Query Agent | `agents/query/agent.py` | 2 | `QueryResponse` | `AnalyticsRefreshed` |
 
 ---
 
@@ -382,6 +385,21 @@ ALTER TABLE job_postings ADD COLUMN IF NOT EXISTS field_confidence JSONB;
 
 - Audit log: 100% completeness required — every trigger, retry, and alert creation must be recorded
 
+### Query Agent (Phase 2 — 9th agent)
+- Standalone workforce intelligence Q&A agent with persona-based response routing
+- Three new output modes beyond Phase 1 Q&A: Gap Analysis, Candidate-Role Match, Stakeholder Reports
+- `QueryPersona` enum: `workforce_board_director | employer_partner | cfa_internal | cohort_student`
+- `QueryRequest` model: `query`, `persona`, `intent_hint` (optional), `max_results`
+- Requires upstream data not in Phase 1: candidate/cohort profiles (new ingestion source)
+- Forward-compatibility: `persona` field added to query API schema in Week 6 (Phase 1 ignores it; Phase 2 uses it for routing)
+- Phase 1 Q&A (inside Analytics Agent) handles: intent classification, evidence citation, Comparative Analysis, Trend Narrative
+- Phase 2 Query Agent handles: Gap Analysis, Candidate-Role Match, Stakeholder Reports, persona routing, formatted document generation (PDF/DOCX)
+
+### Analytics Agent — Phase 2 Expansion
+- Absorbs Demand Analysis Agent capabilities: time-series indexing, velocity windows (7d/30d/90d), 30-day demand forecasts, anomaly detection with significance testing, TrajectoryRecord projections
+- Emits `DemandSignalsUpdated` and `DemandAnomaly` events (previously attributed to standalone Demand Analysis Agent)
+- Q&A migrates out to standalone Query Agent in Phase 2; Analytics retains aggregation + disruption + demand analysis
+
 ---
 
 ## Evaluation Targets (non-negotiable — check against these)
@@ -410,6 +428,12 @@ ALTER TABLE job_postings ADD COLUMN IF NOT EXISTS field_confidence JSONB;
 | Orchestration | Mean time to recover (auto) | < 5 min |
 | Orchestration | Audit log completeness | 100% |
 | System | Batch throughput | 1,000 jobs < 5 minutes |
+| Query Agent (Phase 2) | Intent classification accuracy | ≥ 90% |
+| Query Agent (Phase 2) | Response relevance (human eval) | ≥ 85% |
+| Query Agent (Phase 2) | Persona routing accuracy | ≥ 95% |
+| Analytics (Phase 2) | Forecast MAPE (30-day) | < 15% |
+| Analytics (Phase 2) | Trend accuracy | ≥ 85% |
+| Analytics (Phase 2) | Anomaly precision | ≥ 80% |
 
 ---
 
@@ -439,6 +463,7 @@ ALTER TABLE job_postings ADD COLUMN IF NOT EXISTS field_confidence JSONB;
 | 10 | Testing + security review + load testing | Integration test suite, security checklist, 1k-job load test, Dockerfile |
 | 11 | Documentation | ARCHITECTURE.md, EVENT_CATALOG.md, RUNBOOK.md, CONFIGURATION.md, DEMO_SCRIPT.md |
 | 12 | Capstone demo + release | Live demo to stakeholders, `v0.1.0-capstone` tag, handoff package, retrospective |
+| Phase 2 | Query Agent (9th agent) | Standalone Q&A: Gap Analysis, Candidate-Role Match, Stakeholder Reports, persona routing |
 
 ---
 
@@ -512,7 +537,7 @@ python -m pytest agents/tests/ -v
 - Do NOT use Prisma from Python — SQLAlchemy only
 - Do NOT write to `job_postings` without a resolved `company_id`
 - Do NOT store credentials in code or logs
-- Do NOT implement Phase 2 items (circuit-breaking, saga, admin API, demand analysis, full enrichment, external bus)
+- Do NOT implement Phase 2 items (circuit-breaking, saga, admin API, demand analysis (now Analytics Phase 2), Query Agent, full enrichment, external bus)
 - Do NOT skip writing tests alongside implementation
 - Do NOT modify the Next.js app or `prisma/schema.prisma` unless explicitly instructed
 - Do NOT serve a blank dashboard page — always serve stale data with a staleness banner

--- a/docs/planning/ARCHITECTURAL_DECISIONS.md
+++ b/docs/planning/ARCHITECTURAL_DECISIONS.md
@@ -75,6 +75,8 @@ weight it carries and who owns it.
 | 28 | Contract | Agent health interface | Every agent exposes `health_check() → dict` — returns `{"status": "ok"\|"degraded"\|"down", "agent": str, "last_run": str, "metrics": dict}`, called by Orchestration Agent before scheduling |
 | 29 | Contract | Correlation ID propagation | Set once at pipeline entry, propagated unchanged through every downstream event |
 | 30 | Contract | Taxonomy store abstraction | `TaxonomyStoreBase` ABC — concrete implementation switchable via `TAXONOMY_STORE` env var. Phase 1: `PostgreSQLTaxonomyStore`. Phase 2: `LightcastTaxonomyStore` |
+| 31 | Architectural | Phased Query Agent architecture | Phase 1: Q&A inside Analytics Agent. Phase 2: standalone Query Agent (9th agent) with persona routing |
+| 32 | Architectural | Demand Analysis absorbed into Analytics | Demand Analysis capabilities merged into Analytics Agent Phase 2; `agents/demand_analysis/` repurposed for Query Agent. Final count: Phase 1 = 8, Phase 2 = 9 |
 
 ### Open — Must Resolve Before Build
 
@@ -453,6 +455,38 @@ Requires `LIGHTCAST_API_KEY`.
 
 **Mock for testing:** `MockTaxonomyStore` — returns deterministic fixture data.
 No database connection required. Used in all unit tests.
+
+---
+
+### #31 — Phased Query Agent Architecture
+
+| Field | Value |
+|---|---|
+| **Type** | Architectural (Fixed) |
+| **Status** | ✅ Resolved |
+
+**Context:** The CFA director requested standalone Query Agent capabilities for workforce intelligence Q&A (gap analysis, candidate-role matching, stakeholder reports). The existing 8-agent architecture handles Q&A as a sub-capability of the Analytics Agent (Week 8). Adding a standalone Query Agent during the 12-week curriculum would require restructuring the event pipeline, redefining agent boundaries, and invalidating weeks of student work.
+
+**Resolution:** Phased approach —
+- **Phase 1 (Weeks 1–12):** Q&A remains inside the Analytics Agent. Enhancements include Comparative Analysis and Trend Narrative output modes, 60 evaluation test cases, and a forward-compatible `persona` field on the query API schema (added Week 6, ignored in Phase 1).
+- **Phase 2 (post-capstone):** Standalone Query Agent (9th agent) with Gap Analysis, Candidate-Role Match, and Stakeholder Reports output modes. Persona-based response routing (`workforce_board_director | employer_partner | cfa_internal | cohort_student`). Requires new upstream data: candidate/cohort profiles.
+
+**Rationale:** Preserves the 8-agent architecture during the curriculum while committing to the director's vision in Phase 2. The `persona` field and `QueryRequest` model provide forward-compatibility without scope creep.
+
+---
+
+### #32 — Demand Analysis Capabilities Absorbed into Analytics Agent
+
+| Field | Value |
+|---|---|
+| **Type** | Architectural (Fixed) |
+| **Status** | ✅ Resolved |
+
+**Context:** ARCHITECTURE_DEEP.md originally defined Agent 8 (Demand Analysis Agent) as a Phase 2 standalone agent for time-series indexing, velocity windows, forecasting, and anomaly detection. With the Query Agent becoming the 9th agent, the system would have 10 agents — adding complexity without clear domain separation.
+
+**Resolution:** Demand Analysis capabilities are absorbed into the Analytics Agent's Phase 2 expansion. The Analytics Agent already handles skill velocity (`skill_velocity` table), trajectory mapping (`trajectory_map` table), and emergence detection (`EmergenceAlert` event) in Phase 1. The Demand Analysis scope (extended velocity windows, forecasting, anomaly detection) is the same analytical domain with the same data sources. The `agents/demand_analysis/` scaffold directory is repurposed for the Query Agent.
+
+**Rationale:** "One agent = one responsibility" (Engineering Rule #1). Demand analysis IS analytics — same data, same aggregate tables, same domain. Keeping it separate violates the single-responsibility principle. The Query Agent has genuinely different responsibility (Q&A with persona routing), different consumers (end users), and different outputs (formatted reports). Final count: Phase 1 = 8 agents, Phase 2 = 9 agents.
 
 ---
 

--- a/docs/planning/ARCHITECTURE_DEEP.md
+++ b/docs/planning/ARCHITECTURE_DEEP.md
@@ -543,6 +543,8 @@ class JobRecord(BaseModel):
 **File:** `agents/analytics/agent.py` | **Consumes:** `RecordEnriched` | **Emits:** `AnalyticsRefreshed`, `EmergenceAlert`, `DisruptionRefreshed`
 **Exposes:** `POST /analytics/query` (REST) [Contract #18 — reference implementation]
 
+> **Phase 2 note:** In Phase 2, the Analytics Agent absorbs Demand Analysis capabilities (time-series indexing, velocity windows 7d/30d/90d, 30-day demand forecasts, anomaly detection with significance testing, TrajectoryRecord projections). Q&A migrates out to the standalone Query Agent (Agent 9). The `persona` field is added to the query API in Week 6 for forward-compatibility — Phase 1 ignores it; Phase 2 Query Agent uses it for response routing.
+
 **Phase 1 responsibilities:**
 
 **10 aggregate tables** (replacing single `analytics_aggregates`):
@@ -723,7 +725,7 @@ class JobRecord(BaseModel):
 
 ---
 
-### 8. Demand Analysis Agent *(Phase 2 only — scaffold directory, do not implement)*
+### 8. Demand Analysis *(Phase 2 — capabilities absorbed into Analytics Agent expansion)*
 **File:** `agents/demand_analysis/agent.py` | **Consumes:** `RecordEnriched`, `AnalyticsRefreshed` | **Emits:** `DemandSignalsUpdated`, `DemandAnomaly`
 
 **Phase 2 scope (enriched from client spec):**
@@ -747,6 +749,41 @@ class JobRecord(BaseModel):
 | Anomaly precision | ≥ 80% |
 | Trajectory confidence calibration | Within ±10% |
 
+> **Architecture note:** The Demand Analysis capabilities listed above are absorbed into the Analytics Agent in Phase 2. The `agents/demand_analysis/` scaffold directory is repurposed for the Query Agent. This avoids a 10-agent system — demand analysis is analytics-domain work (same data sources, same aggregate tables). See Agent 9 below.
+
+---
+
+### 9. Query Agent *(Phase 2 — standalone workforce intelligence Q&A)*
+**File:** `agents/query/agent.py` | **Consumes:** `AnalyticsRefreshed`, `DisruptionRefreshed` | **Emits:** `QueryResponse`
+
+**Phase 2 scope:**
+- Standalone workforce intelligence Q&A agent — migrates Q&A responsibility out of the Analytics Agent
+- Three new output modes beyond Phase 1 Q&A:
+  - **Gap Analysis:** Compare candidate/cohort skills against market demand (requires candidate profile data — new ingestion source)
+  - **Candidate-Role Match:** Score individual candidates against open roles using job requirements + candidate capabilities
+  - **Stakeholder Reports:** Formatted PDF/DOCX board briefs, not just Streamlit pages
+- **Persona-based response routing:**
+  - `QueryPersona` enum: `workforce_board_director | employer_partner | cfa_internal | cohort_student`
+  - Different output depth, format, and focus per persona
+- **`QueryRequest` Pydantic model:**
+  - `query: str` — natural language question
+  - `persona: QueryPersona` — routing hint for response style
+  - `intent_hint: str | None` — optional intent override
+  - `max_results: int` — result limit
+- Forward-compatibility: `persona` field added to query API in Week 6 (Phase 1). Phase 1 ignores it; Phase 2 uses it for routing.
+
+**Phase 1 → Phase 2 migration:**
+- Phase 1: Q&A is embedded in Analytics Agent (intent classification, evidence citation, Comparative Analysis, Trend Narrative)
+- Phase 2: Q&A migrates to standalone Query Agent. Analytics retains aggregation + disruption + demand analysis (absorbed from Agent 8).
+
+| Metric | Target |
+|--------|--------|
+| Intent classification accuracy | ≥ 90% |
+| Response relevance (human eval) | ≥ 85% |
+| Persona routing accuracy | ≥ 95% |
+| Evidence citation rate | 100% (every answer cites specific data) |
+| Query response time (p50) | < 5s |
+
 ---
 
 ## Event Catalog
@@ -756,18 +793,19 @@ class JobRecord(BaseModel):
 | `IngestBatch` | Ingestion | Normalization, Orchestrator | batch_id, record_count, source |
 | `NormalizationComplete` | Normalization | Work Intelligence, Orchestrator | batch_id, normalized_count, quarantine_count |
 | `SkillsExtracted` | Work Intelligence | Enrichment, Orchestrator | batch_id, per-dimension counts (skills, tools, tasks, responsibilities, context), extraction_cost_usd |
-| `RecordEnriched` | Enrichment | Analytics, Demand Analysis*, Orchestrator | batch_id, enriched_count, temporal_period, borderplex_subregion, duplicate_count |
+| `RecordEnriched` | Enrichment | Analytics, Orchestrator | batch_id, enriched_count, temporal_period, borderplex_subregion, duplicate_count |
 | `ProfileComplete` | Work Intelligence | Enrichment | record_id — mirrors client spec naming (alias for per-record SkillsExtracted) |
 | `AnalyticsRefreshed` | Analytics | Visualization, Orchestrator | refresh_id, tables_updated, records_processed |
 | `DisruptionRefreshed` | Analytics | Visualization, Orchestrator | refresh_id, roles_analyzed, new_fingerprints |
 | `EmergenceAlert` | Analytics | Orchestrator | cluster_id, posting_count, representative_titles — new canonical role candidates |
-| `DemandSignalsUpdated` | Demand Analysis* | Analytics, Visualization, Orchestrator | *Phase 2* |
-| `DemandAnomaly` | Demand Analysis* | Orchestrator | *Phase 2* |
+| `DemandSignalsUpdated` | Analytics (Phase 2) | Analytics, Visualization, Orchestrator | *Phase 2* |
+| `DemandAnomaly` | Analytics (Phase 2) | Orchestrator | *Phase 2* |
+| `QueryResponse` | Query Agent (Phase 2) | Visualization, Orchestrator | query_id, persona, intent, response_format, evidence_count |
 | `RenderComplete` | Visualization | Orchestrator | page, render_time_ms |
 | `*Failed` / `*Alert` | Any agent | **Orchestrator only** | error_type, severity, context |
 | `SourceFailure` | Ingestion | Orchestrator | source, error, retry_count |
 
-*Phase 2
+*Phase 2 — Demand Analysis capabilities absorbed into Analytics Agent
 
 ---
 
@@ -938,7 +976,7 @@ AZURE_OPENAI_EMBEDDING_DEPLOYMENT_NAME=
 # Architectural #19 — Database (PostgreSQL — fixed)
 # POSTGRES MIGRATION: change from sqlserver:// to postgresql://
 DATABASE_URL=                          # Prisma / Next.js connection string
-# POSTGRES MIGRATION: change from mssql+pyodbc:// to postgresql+psycopg2://
+# PostgreSQL connection: postgresql+psycopg2://
 PYTHON_DATABASE_URL=                   # SQLAlchemy connection string (Python agents)
 
 # Tool #17 — Agent tracing (reference: LangSmith)
@@ -986,6 +1024,7 @@ COST_ALERT_THRESHOLD_USD=50.0                  # Alert when cumulative cost exce
 | 10 | **Pipeline Hardening** + Event Contract Enforcement |
 | 11 | **Testing + Security + Documentation** (merged) |
 | 12 | Capstone demo + `v0.1.0-capstone` |
+| Phase 2 | Query Agent (9th agent) — Gap Analysis, Candidate-Role Match, Stakeholder Reports, persona routing |
 
 ---
 


### PR DESCRIPTION
## Summary
- Add Query Agent as 9th agent (Phase 2) to CLAUDE.md, ARCHITECTURE_DEEP.md, and ARCHITECTURAL_DECISIONS.md
- Absorb Demand Analysis Agent capabilities into Analytics Agent Phase 2 expansion
- Add Decisions 31 (Phased Query Agent) and 32 (Demand Analysis absorption)

## Context
CFA director requested standalone Query Agent. Phased approach preserves 8-agent architecture during curriculum (Phase 1). Phase 2 adds Query Agent with Gap Analysis, Candidate-Role Match, Stakeholder Reports, and persona routing. Demand Analysis absorbed into Analytics (same domain) to keep count at 9.

## Files changed
- `CLAUDE.md` — architecture diagram, agent table, eval targets, build order
- `docs/planning/ARCHITECTURE_DEEP.md` — Agent 9 spec, Analytics Phase 2 note, event catalog
- `docs/planning/ARCHITECTURAL_DECISIONS.md` — Decisions #31, #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)