### PR TITLE
fix: run idempotent migrations at pipeline startup

### DIFF
--- a/agents/pipeline_runner.py
+++ b/agents/pipeline_runner.py
@@ -64,6 +64,8 @@ load_dotenv(_REPO_ROOT / ".env")
 import structlog  # noqa: E402
 
 from agents.analytics.agent import AnalyticsAgent  # noqa: E402
+from agents.common.data_store.database import get_engine  # noqa: E402
+from agents.common.data_store.migrations import run_migrations  # noqa: E402
 from agents.common.event_envelope import EventEnvelope  # noqa: E402
 from agents.common.types import JobRecord  # noqa: E402
 from agents.demand_analysis.agent import DemandAnalysisAgent  # noqa: E402
@@ -101,6 +103,12 @@ structlog.configure(
 )
 
 log = structlog.get_logger()
+
+# ---------------------------------------------------------------------------
+# Idempotent migrations — ensure agent tables and columns exist before run
+# ---------------------------------------------------------------------------
+
+run_migrations(get_engine())
 
 # ---------------------------------------------------------------------------
 # Pipeline definition


### PR DESCRIPTION
## Summary
- `pipeline_runner.py` now calls `run_migrations(get_engine())` at startup
- Previously, migrations only ran via `--migrate` CLI flag or `db_check.py migrate`
- This caused enrichment failures (missing columns) when running against a fresh or cloud database
- All DDL is `CREATE IF NOT EXISTS` / `ADD COLUMN IF NOT EXISTS` — safe on every invocation

## Test plan
- [x] Ran full pipeline against cloud Azure PostgreSQL DB — all 8 agents completed successfully
- [x] Migrations logged as idempotent (no errors on existing tables)
- [x] 25 Borderplex job postings ingested, normalized, and 10 extracted

🤖 Generated with [Claude Code](https://claude.com/claude-code)