### PR TITLE
fix: pass date_posted through to normalization mapper

### DIFF
--- a/agents/normalization/agent.py
+++ b/agents/normalization/agent.py
@@ -157,7 +157,7 @@ def normalize_records(state: NormalizationState) -> NormalizationState:
                     state=raw_dict.get("state"),
                     country=raw_dict.get("country"),
                     is_remote=raw_dict.get("is_remote"),
-                    date_posted=None,  # Will be parsed by mapper
+                    date_posted=raw_dict.get("date_posted"),
                     job_url=raw_dict.get("job_url"),
                     source_url=raw_dict.get("source_url") or "",
                     employment_type=raw_dict.get("employment_type"),

--- a/agents/skills_extraction/agent.py
+++ b/agents/skills_extraction/agent.py
@@ -385,11 +385,11 @@ class SkillsExtractionAgent(BaseAgent):
         if not work_items:
             return self._legacy_fixture_response(event)
 
-        # Cap work items per run for faster pipeline runs (default 10; set SKILLS_EXTRACTION_MAX_JOBS to override)
+        # Cap work items per run (0 = no limit; set SKILLS_EXTRACTION_MAX_JOBS to override)
         try:
-            max_jobs = int(os.environ.get("SKILLS_EXTRACTION_MAX_JOBS", "10"))
+            max_jobs = int(os.environ.get("SKILLS_EXTRACTION_MAX_JOBS", "0"))
         except (TypeError, ValueError):
-            max_jobs = 10
+            max_jobs = 0
         if max_jobs > 0 and len(work_items) > max_jobs:
             work_items = work_items[:max_jobs]
 


### PR DESCRIPTION
## Summary
- **fix: date_posted** — `agents/normalization/agent.py` line 160 was hardcoding `date_posted=None` instead of passing through the value from `raw_ingested_jobs`. Changed to `raw_dict.get("date_posted")`.
- **fix: skills extraction cap** — `agents/skills_extraction/agent.py` defaulted `SKILLS_EXTRACTION_MAX_JOBS` to `10`, silently skipping jobs beyond the first 10. Changed default to `0` (no limit). Can still be overridden via env var.

Fixes #122
Fixes #124

## Test plan
- [ ] CI passes (npm build + pytest)
- [ ] Run pipeline and verify `normalized_jobs.date_posted` is populated for records where `raw_ingested_jobs.date_posted` is non-null
- [ ] Verify skills extraction processes all normalized jobs, not just the first 10

🤖 Generated with [Claude Code](https://claude.com/claude-code)