### PR TITLE
arch: flywheel ingestion/processing + zip code resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,6 @@ agents/skills_extraction/taxonomy/skills_en.csv
 agents/skills_extraction/taxonomy/onet_skills.txt
 # ESCO embedding disk cache (deprecated — use PostgreSQL pgvector)
 agents/skills_extraction/taxonomy/cache/
+
+# Debug scratch scripts (local dev only)
+_debug_*.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -510,8 +510,17 @@ py -3.11 -m venv agents/.venv               # Windows
 agents\.venv\Scripts\Activate.ps1            # Windows PowerShell
 pip install -r agents/requirements.txt
 
-# Run the walking skeleton pipeline (Week 2+) — single-pass demo
-python agents/pipeline_runner.py
+# --- Flywheel pipeline (production) — decoupled ingestion + processing ---
+# Loop 1: Bulk ingest from JSearch (budget-aware, key rotation)
+python agents/scripts/batch_ingest.py              # run all queries from config
+python agents/scripts/batch_ingest.py --dry-run    # show plan without API calls
+
+# Loop 2: Paced processing (normalize → extract → enrich)
+python agents/scripts/run_processing_loop.py --batch-size 50 --delay 2
+python agents/scripts/run_processing_loop.py --dry-run        # show pending counts
+
+# Seed local DB with enriched data (dev setup)
+python scripts/pg-seed-data/seed_agent_data.py
 
 # Run the Streamlit dashboard
 streamlit run agents/dashboard/streamlit_app.py
@@ -519,18 +528,12 @@ streamlit run agents/dashboard/streamlit_app.py
 # Run agent tests
 python -m pytest agents/tests/ -v
 
-# --- Flywheel pattern (Week 6+) — decoupled ingestion + processing ---
-# Loop 1: Bulk ingest from JSearch (budget-aware, key rotation)
-python agents/scripts/batch_ingest_borderplex.py              # run all queries
-python agents/scripts/batch_ingest_borderplex.py --dry-run    # show plan without API calls
-
-# Loop 2: Paced processing (normalize → extract → enrich)
-python agents/scripts/run_processing_loop.py --batch-size 50 --delay 2
-python agents/scripts/run_processing_loop.py --dry-run        # show pending counts
-
-# Run a single agent manually (Week 3+)
+# Run a single agent manually
 # python -m agents.ingestion.agent --source jsearch --limit 50
 # python -m agents.ingestion.agent --source crawl4ai --limit 50
+
+# Demo run: Walking skeleton single-pass with fixture data (Week 2 demo only)
+# python agents/pipeline_runner.py
 ```
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -454,14 +454,14 @@ ALTER TABLE job_postings ADD COLUMN IF NOT EXISTS field_confidence JSONB;
 | 1 | Environment + first scrape + basic Streamlit | Working Python env, raw JSON scrape, Streamlit prototype |
 | 2 | LLM adapter + walking skeleton | `llm_adapter.py`, 8 agent stubs, pipeline runner, journey dashboard |
 | 3 | Ingestion Agent + Normalization Agent | `IngestBatch`/`NormalizationComplete` events, staging tables, APScheduler |
-| 4 | Skills Extraction Agent + eval harness + Enrichment-lite | `SkillsExtracted` event, eval dataset (30–50 labeled), prompt iteration log |
-| 5 | Visualization Agent | Production Streamlit dashboards, PDF/CSV/JSON export, live PostgreSQL connection |
-| 6 | Orchestration Agent | Scheduling, alerting tiers, retry policies, audit log, Operations & Alerts page |
+| 4 | Work Intelligence Agent Part 1 | Skills + Tools + Taxonomy + Cost Modeling, `SkillsExtracted` event, eval dataset (30–50 labeled) |
+| 5 | Work Intelligence Agent Part 2 + Enrichment-lite | Tasks + Responsibilities + Context extraction, prompt iteration log |
+| 6 | Enrichment Agent (Full Phase 1) + Visualization Foundations | Temporal/borderplex classification, fuzzy dedup, quality/spam scoring, Streamlit dashboards |
 | 7 | Analytics Agent — aggregates + weekly insights | Aggregate tables, LLM summaries, template fallback, `AnalyticsRefreshed` event |
 | 8 | Analytics Agent — Ask the Data | Text-to-SQL, SQL guardrails + unit tests, “Ask the Data” Streamlit page |
-| 9 | Pipeline hardening | Near-dedup in Ingestion, event contract enforcement, enrichment tuning, perf benchmark |
-| 10 | Testing + security review + load testing | Integration test suite, security checklist, 1k-job load test, Dockerfile |
-| 11 | Documentation | ARCHITECTURE.md, EVENT_CATALOG.md, RUNBOOK.md, CONFIGURATION.md, DEMO_SCRIPT.md |
+| 9 | Orchestration Agent + Visualization Completion | Scheduling, alerting tiers, retry policies, audit log, Operations & Alerts page, PDF/CSV/JSON export |
+| 10 | Pipeline hardening + event contract enforcement | Near-dedup in Ingestion, enrichment tuning, perf benchmark, 1k-job load test |
+| 11 | Testing + security + documentation | Integration test suite, security checklist, Dockerfile, ARCHITECTURE.md, RUNBOOK.md |
 | 12 | Capstone demo + release | Live demo to stakeholders, `v0.1.0-capstone` tag, handoff package, retrospective |
 | Phase 2 | Query Agent (9th agent) | Standalone Q&A: Gap Analysis, Candidate-Role Match, Stakeholder Reports, persona routing |
 
@@ -510,7 +510,7 @@ py -3.11 -m venv agents/.venv               # Windows
 agents\.venv\Scripts\Activate.ps1            # Windows PowerShell
 pip install -r agents/requirements.txt
 
-# Run the walking skeleton pipeline (Week 2+)
+# Run the walking skeleton pipeline (Week 2+) — single-pass demo
 python agents/pipeline_runner.py
 
 # Run the Streamlit dashboard
@@ -519,9 +519,14 @@ streamlit run agents/dashboard/streamlit_app.py
 # Run agent tests
 python -m pytest agents/tests/ -v
 
-# --- Later weeks (not yet available) ---
-# Run full pipeline via Orchestration Agent scheduler (Week 6)
-# python -m agents.orchestration.scheduler
+# --- Flywheel pattern (Week 6+) — decoupled ingestion + processing ---
+# Loop 1: Bulk ingest from JSearch (budget-aware, key rotation)
+python agents/scripts/batch_ingest_borderplex.py              # run all queries
+python agents/scripts/batch_ingest_borderplex.py --dry-run    # show plan without API calls
+
+# Loop 2: Paced processing (normalize → extract → enrich)
+python agents/scripts/run_processing_loop.py --batch-size 50 --delay 2
+python agents/scripts/run_processing_loop.py --dry-run        # show pending counts
 
 # Run a single agent manually (Week 3+)
 # python -m agents.ingestion.agent --source jsearch --limit 50

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -218,9 +218,25 @@ See [scripts/pg-seed-data/README.md](scripts/pg-seed-data/README.md) for details
 
 ### Agent Pipeline
 
-The **Job Intelligence Engine** is an eight-agent Python pipeline that will ingest, normalize, enrich, and analyze external job postings alongside the Next.js app. The `agents/` directory is scaffolded; the pipeline is built out over the **12-week curriculum** as specified in [CLAUDE.md](CLAUDE.md).
+The **Job Intelligence Engine** is an eight-agent Python pipeline that ingests, normalizes, enriches, and analyzes external job postings alongside the Next.js app. The pipeline uses a **flywheel pattern** — ingestion and processing run as independent loops.
 
-**Walking skeleton (Week 2+):**
+**Seed local DB with enriched data (first time):**
+
+```bash
+python scripts/pg-seed-data/seed_agent_data.py
+```
+
+**Flywheel pipeline (production):**
+
+```bash
+# Loop 1: Bulk ingest from JSearch API
+python agents/scripts/batch_ingest.py
+
+# Loop 2: Paced processing (normalize → extract → enrich)
+python agents/scripts/run_processing_loop.py --batch-size 50 --delay 2
+```
+
+**Demo run (fixture data only, Week 2 demo):**
 
 ```bash
 python agents/pipeline_runner.py

--- a/README.md
+++ b/README.md
@@ -49,27 +49,68 @@ cd watechcoalition
 - `seed`: Seeds the MSSQL database with synthetic/faker-generated data via Prisma (deprecated).
 - `lint`: Runs ESLint to check for code issues.
 
-## Agent Pipeline (Walking Skeleton)
+## Agent Pipeline (Flywheel Architecture)
 
-The **Job Intelligence Engine** is an eight-agent Python pipeline that ingests, normalizes, enriches, and analyzes external job postings. The walking skeleton (Week 2) is functional — all eight agent stubs process 10 demo job postings end-to-end with fixture data. Real agent logic is built out over the 12-week curriculum.
+The **Job Intelligence Engine** is an eight-agent Python pipeline that ingests, normalizes, enriches, and analyzes external job postings. The pipeline uses a **flywheel pattern**: ingestion (cheap HTTP) is decoupled from processing (LLM-based extraction and enrichment) so each loop runs independently at its own pace.
 
 See [CLAUDE.md](CLAUDE.md) for full architecture details, agent specs, and build order.
 
+### Setup (one time)
+
 ```bash
-# Setup (one time — from repo root)
 py -3.11 -m venv agents/.venv
 agents\.venv\Scripts\Activate.ps1          # Windows PowerShell
 pip install -r agents/requirements.txt
+```
 
-# Run the pipeline (produces agents/data/output/pipeline_run.json)
-python agents/pipeline_runner.py
+### Seed Local Database with Enriched Data
 
-# Run the Streamlit dashboard (http://localhost:8501)
+New devs should seed their local database with pre-processed job postings so analytics and visualization have data to work with:
+
+```bash
+python scripts/pg-seed-data/seed_agent_data.py
+```
+
+This imports enriched records from `scripts/pg-seed-data/agent-fixtures/` using UPSERT (safe to run multiple times).
+
+### Run the Pipeline
+
+```bash
+# Loop 1: Bulk ingest from JSearch API (budget-aware, key rotation)
+python agents/scripts/batch_ingest.py              # run all queries from config
+python agents/scripts/batch_ingest.py --dry-run    # preview without API calls
+
+# Loop 2: Paced processing (normalize → extract → enrich)
+python agents/scripts/run_processing_loop.py --batch-size 50 --delay 2
+
+# Streamlit dashboard (http://localhost:8501)
 streamlit run agents/dashboard/streamlit_app.py
 
-# Run agent tests
+# Agent tests
 python -m pytest agents/tests/ -v
 ```
+
+### Environment Variables (Pipeline)
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `PYTHON_DATABASE_URL` | Yes | PostgreSQL connection string |
+| `JSEARCH_API_KEY` | For ingestion | RapidAPI JSearch key (primary) |
+| `JSEARCH_API_KEY_2` | Optional | Second JSearch key for budget rotation |
+| `NORM_BATCH_SIZE` | Optional | Records per processing batch (default: 50) |
+| `PROCESSING_DELAY` | Optional | Seconds between processing batches (default: 10) |
+| `AZURE_OPENAI_*` | For extraction/enrichment | Azure OpenAI credentials |
+
+### Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `agents/scripts/batch_ingest.py` | Loop 1 — budget-aware JSearch ingestion |
+| `agents/scripts/run_processing_loop.py` | Loop 2 — paced normalize/extract/enrich |
+| `scripts/pg-seed-data/seed_agent_data.py` | Import enriched data to local DB |
+| `scripts/pg-seed-data/export_agent_data.py` | Export pipeline data to JSON fixtures (admin) |
+| `scripts/pg-seed-data/clean_stale_postings.py` | Purge old pipeline data before re-seeding (admin) |
+| `agents/config/ingestion_queries.yaml` | Editable query configuration for batch_ingest |
 
 ## Technologies Used
 
@@ -86,7 +127,7 @@ python -m pytest agents/tests/ -v
 - **SQLAlchemy**: Python database access (PostgreSQL via psycopg2). [SQLAlchemy Documentation](https://docs.sqlalchemy.org/)
 - **Streamlit**: Read-only analytics dashboards. [Streamlit Documentation](https://docs.streamlit.io/)
 - **Redis Streams**: Inter-agent event bus (`XADD`/`XREADGROUP`/`XACK`). [Redis Streams Documentation](https://redis.io/docs/data-types/streams/)
-- **LangSmith**: Agent tracing and evaluation. [LangSmith Documentation](https://docs.smith.langchain.com/)
+- **Langfuse**: LLM observability and tracing. [Langfuse Documentation](https://langfuse.com/docs)
 
 ## License
 

--- a/agents/README.md
+++ b/agents/README.md
@@ -8,7 +8,18 @@ From repo root with venv activated:
 
 ```bash
 pip install -r agents/requirements.txt
-python agents/pipeline_runner.py
+
+# Seed local DB with enriched data (first time)
+python scripts/pg-seed-data/seed_agent_data.py
+
+# Flywheel pipeline (production)
+python agents/scripts/batch_ingest.py                          # Loop 1: ingest
+python agents/scripts/run_processing_loop.py --batch-size 50   # Loop 2: process
+
+# Demo run (fixture data only, Week 2 demo)
+# python agents/pipeline_runner.py
+
+# Streamlit dashboard
 streamlit run agents/dashboard/app.py
 # (alias) streamlit run agents/dashboard/streamlit_app.py
 ```

--- a/agents/common/data_store/migrations.py
+++ b/agents/common/data_store/migrations.py
@@ -95,6 +95,8 @@ _JOB_POSTINGS_ALTER_STATEMENTS = [
     # Fuzzy dedup (IMP-018): cached embedding + content hash for same-company window search
     "ALTER TABLE dbo.job_postings ADD COLUMN IF NOT EXISTS dedup_text_hash TEXT",
     "ALTER TABLE dbo.job_postings ADD COLUMN IF NOT EXISTS dedup_embedding vector(1536)",
+    # Zip code (flywheel #161): resolved during normalization from posting or postal_geo_data lookup
+    "ALTER TABLE dbo.job_postings ADD COLUMN IF NOT EXISTS zip_code VARCHAR(10)",
 ]
 
 # Legacy Prisma cleanup: drop FK constraints and make NOT NULL columns nullable (#159).
@@ -115,6 +117,8 @@ _JOB_POSTINGS_LEGACY_CLEANUP = [
 _NORMALIZED_JOBS_ALTER_STATEMENTS = [
     "ALTER TABLE dbo.normalized_jobs ADD COLUMN IF NOT EXISTS requirements TEXT",
     "ALTER TABLE dbo.normalized_jobs ADD COLUMN IF NOT EXISTS responsibilities TEXT",
+    "ALTER TABLE dbo.normalized_jobs ADD COLUMN IF NOT EXISTS zip_code VARCHAR(10)",
+    "ALTER TABLE dbo.raw_ingested_jobs ADD COLUMN IF NOT EXISTS zip_code VARCHAR(10)",
 ]
 
 # Company HQ / location fields for enrichment resolve_location (#110)

--- a/agents/common/data_store/models.py
+++ b/agents/common/data_store/models.py
@@ -70,6 +70,7 @@ class RawIngestedJob(Base):
     city: Mapped[str | None] = mapped_column(String(255), nullable=True)
     state: Mapped[str | None] = mapped_column(String(100), nullable=True)
     country: Mapped[str | None] = mapped_column(String(10), nullable=True)
+    zip_code: Mapped[str | None] = mapped_column(String(10), nullable=True)
     is_remote: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
 
     # URLs
@@ -158,6 +159,7 @@ class NormalizedJob(Base):
     city: Mapped[str | None] = mapped_column(String(255), nullable=True)
     state_province: Mapped[str | None] = mapped_column(String(100), nullable=True)
     country: Mapped[str | None] = mapped_column(String(10), nullable=True)
+    zip_code: Mapped[str | None] = mapped_column(String(10), nullable=True)
     work_arrangement: Mapped[str | None] = mapped_column(String(20), nullable=True)
     is_remote: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
 
@@ -420,3 +422,24 @@ class SOCC(Base):
     version: Mapped[str] = mapped_column(Text, nullable=False)
     createdat: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
     updatedat: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+
+
+class PostalGeoData(Base):
+    """US zip code reference — read-only lookup table.
+
+    Provides city, county, state, lat/lng for zip code resolution.
+    Used by normalization to resolve zip_code from city+state when
+    the source posting doesn't include a zip. County and other fields
+    are always looked up via JOIN, never stored redundantly on job tables.
+    """
+
+    __tablename__ = "postal_geo_data"
+    __table_args__ = {"schema": "dbo"}
+
+    zip: Mapped[str] = mapped_column(String(5), primary_key=True)
+    city: Mapped[str] = mapped_column(String(100), nullable=False)
+    county: Mapped[str] = mapped_column(String(100), nullable=False)
+    state_code: Mapped[str] = mapped_column(String(2), nullable=False)
+    state: Mapped[str] = mapped_column(String(100), nullable=False)
+    lat: Mapped[float] = mapped_column(Float, nullable=False)
+    lng: Mapped[float] = mapped_column(Float, nullable=False)

--- a/agents/common/types/job_record.py
+++ b/agents/common/types/job_record.py
@@ -35,6 +35,7 @@ class JobRecord(BaseModel):
     city: str | None = None
     state_province: str | None = None
     country: str | None = None
+    zip_code: str | None = None
     work_arrangement: str | None = None
     is_remote: bool | None = None
 

--- a/agents/common/types/raw_job_record.py
+++ b/agents/common/types/raw_job_record.py
@@ -29,6 +29,7 @@ class RawJobRecord(BaseModel):
     city: str | None = None
     state: str | None = None
     country: str | None = None
+    zip_code: str | None = None
     is_remote: bool | None = None
 
     # Dates

--- a/agents/config/ingestion_queries.yaml
+++ b/agents/config/ingestion_queries.yaml
@@ -1,37 +1,61 @@
 # Ingestion query configuration for batch_ingest_borderplex.py
 #
-# Each query = 1 API request per page (10 results/page).
-# Total requests per run = sum of all query `pages` values.
+# Round 3: additional query variants to push past 1000 raw records.
+# Key 1 is exhausted (429). Key 2 has ~320 requests remaining.
 #
 # API keys: set JSEARCH_API_KEY and JSEARCH_API_KEY_2 in .env
 # Primary key is used first; rotates to secondary on budget limit or 429.
 #
 # Budget: 500 free requests/month per RapidAPI key.
-# The script rotates to the next key when budget_per_key is hit or a 429 is received.
 
 budget_per_key: 500
 
 queries:
-  - name: ai-engineering
-    keywords: ["AI engineer", "machine learning engineer"]
+  # --- Round 3: new keyword variants to avoid dedup overlap ---
+  - name: react-frontend
+    keywords: ["React developer", "frontend engineer", "TypeScript developer"]
     pages: 10
 
-  - name: data-science
-    keywords: ["data scientist", "data analyst", "data engineer"]
+  - name: java-enterprise
+    keywords: ["Java developer", "Java engineer", "Spring Boot developer"]
     pages: 10
 
-  - name: prompt-llm
-    keywords: ["prompt engineer", "LLM", "generative AI"]
+  - name: systems-engineer
+    keywords: ["systems engineer", "Linux engineer", "systems administrator"]
     pages: 10
 
-  - name: software-engineering
-    keywords: ["software engineer", "backend developer", "full stack"]
+  - name: blockchain-web3
+    keywords: ["blockchain developer", "Web3 engineer", "smart contract developer"]
     pages: 10
 
-  - name: devops-cloud
-    keywords: ["DevOps engineer", "cloud architect", "platform engineer"]
-    pages: 5
+  - name: data-governance
+    keywords: ["data governance analyst", "data quality engineer", "data steward"]
+    pages: 10
 
-  - name: cybersecurity
-    keywords: ["cybersecurity analyst", "security engineer"]
-    pages: 5
+  - name: ai-safety
+    keywords: ["AI safety engineer", "responsible AI", "AI ethics"]
+    pages: 10
+
+  - name: mobile-dev
+    keywords: ["mobile developer", "iOS developer", "Android developer"]
+    pages: 10
+
+  - name: database-engineer
+    keywords: ["database engineer", "DBA", "database architect"]
+    pages: 10
+
+  - name: rust-go-modern
+    keywords: ["Rust developer", "Go developer", "Golang engineer"]
+    pages: 10
+
+  - name: ml-scientist
+    keywords: ["machine learning scientist", "applied ML", "ML researcher"]
+    pages: 10
+
+  - name: technical-lead
+    keywords: ["technical lead", "engineering manager", "staff engineer"]
+    pages: 10
+
+  - name: platform-engineer
+    keywords: ["platform engineer", "developer experience", "internal tools engineer"]
+    pages: 10

--- a/agents/config/ingestion_queries.yaml
+++ b/agents/config/ingestion_queries.yaml
@@ -1,61 +1,63 @@
-# Ingestion query configuration for batch_ingest_borderplex.py
+# Ingestion query configuration for batch_ingest.py
 #
-# Round 3: additional query variants to push past 1000 raw records.
-# Key 1 is exhausted (429). Key 2 has ~320 requests remaining.
-#
-# API keys: set JSEARCH_API_KEY and JSEARCH_API_KEY_2 in .env
-# Primary key is used first; rotates to secondary on budget limit or 429.
-#
-# Budget: 500 free requests/month per RapidAPI key.
+# Broad keyword queries targeting AI/agentic roles and adjacent tech.
+# Region filtering happens at enrichment (borderplex_subregion classifier),
+# NOT at ingestion — ingest broadly, filter on consumer side.
 
 budget_per_key: 500
 
 queries:
-  # --- Round 3: new keyword variants to avoid dedup overlap ---
-  - name: react-frontend
-    keywords: ["React developer", "frontend engineer", "TypeScript developer"]
+  # --- Tier 1: Direct agentic/LLM-consumer roles ---
+  - name: agentic-ai
+    keywords: ["AI agent developer", "autonomous systems engineer", "agentic AI"]
     pages: 10
 
-  - name: java-enterprise
-    keywords: ["Java developer", "Java engineer", "Spring Boot developer"]
-    pages: 10
-
-  - name: systems-engineer
-    keywords: ["systems engineer", "Linux engineer", "systems administrator"]
-    pages: 10
-
-  - name: blockchain-web3
-    keywords: ["blockchain developer", "Web3 engineer", "smart contract developer"]
-    pages: 10
-
-  - name: data-governance
-    keywords: ["data governance analyst", "data quality engineer", "data steward"]
+  - name: prompt-llm
+    keywords: ["prompt engineer", "LLM", "generative AI"]
     pages: 10
 
   - name: ai-safety
     keywords: ["AI safety engineer", "responsible AI", "AI ethics"]
+    pages: 5
+
+  - name: ai-research
+    keywords: ["AI researcher", "applied scientist", "research engineer"]
     pages: 10
 
-  - name: mobile-dev
-    keywords: ["mobile developer", "iOS developer", "Android developer"]
+  # --- Tier 2: Strong AI-adjacent (LLM consumers, not model builders) ---
+  - name: ai-engineering
+    keywords: ["AI engineer", "machine learning engineer"]
     pages: 10
 
-  - name: database-engineer
-    keywords: ["database engineer", "DBA", "database architect"]
+  - name: software-engineering
+    keywords: ["software engineer", "backend developer", "full stack"]
     pages: 10
 
-  - name: rust-go-modern
-    keywords: ["Rust developer", "Go developer", "Golang engineer"]
+  - name: python-developer
+    keywords: ["Python developer", "Python engineer"]
     pages: 10
 
+  - name: product-tech
+    keywords: ["technical product manager", "AI product manager"]
+    pages: 10
+
+  - name: data-engineering
+    keywords: ["data engineer", "data pipeline", "ETL developer"]
+    pages: 10
+
+  - name: data-science
+    keywords: ["data scientist", "data analyst", "data engineer"]
+    pages: 10
+
+  # --- Tier 3: ML/model-building roles (breadth) ---
   - name: ml-scientist
     keywords: ["machine learning scientist", "applied ML", "ML researcher"]
     pages: 10
 
-  - name: technical-lead
-    keywords: ["technical lead", "engineering manager", "staff engineer"]
+  - name: deep-learning
+    keywords: ["deep learning engineer", "NLP engineer", "computer vision"]
     pages: 10
 
-  - name: platform-engineer
-    keywords: ["platform engineer", "developer experience", "internal tools engineer"]
-    pages: 10
+  - name: ml-ops
+    keywords: ["MLOps engineer", "ML infrastructure", "model deployment"]
+    pages: 5

--- a/agents/config/ingestion_queries.yaml
+++ b/agents/config/ingestion_queries.yaml
@@ -1,0 +1,37 @@
+# Ingestion query configuration for batch_ingest_borderplex.py
+#
+# Each query = 1 API request per page (10 results/page).
+# Total requests per run = sum of all query `pages` values.
+#
+# API keys: set JSEARCH_API_KEY and JSEARCH_API_KEY_2 in .env
+# Primary key is used first; rotates to secondary on budget limit or 429.
+#
+# Budget: 500 free requests/month per RapidAPI key.
+# The script rotates to the next key when budget_per_key is hit or a 429 is received.
+
+budget_per_key: 500
+
+queries:
+  - name: ai-engineering
+    keywords: ["AI engineer", "machine learning engineer"]
+    pages: 10
+
+  - name: data-science
+    keywords: ["data scientist", "data analyst", "data engineer"]
+    pages: 10
+
+  - name: prompt-llm
+    keywords: ["prompt engineer", "LLM", "generative AI"]
+    pages: 10
+
+  - name: software-engineering
+    keywords: ["software engineer", "backend developer", "full stack"]
+    pages: 10
+
+  - name: devops-cloud
+    keywords: ["DevOps engineer", "cloud architect", "platform engineer"]
+    pages: 5
+
+  - name: cybersecurity
+    keywords: ["cybersecurity analyst", "security engineer"]
+    pages: 5

--- a/agents/docs/INGESTION_QUERY_RESULTS.md
+++ b/agents/docs/INGESTION_QUERY_RESULTS.md
@@ -1,0 +1,164 @@
+# Ingestion Query Keyword Results
+
+Date: 2026-04-03
+Source: JSearch API via `batch_ingest.py`
+Total raw records staged: **1,065** across 32 query variants and 320 API requests (2 keys).
+
+## Budget Summary
+
+
+| Key       | Capacity  | Used     | Remaining | Notes                                     |
+| --------- | --------- | -------- | --------- | ----------------------------------------- |
+| Key 1     | 500       | ~500     | 0         | Exhausted (429) from prior runs + round 2 |
+| Key 2     | 500       | ~320     | ~180      | Round 2 (200 req) + Round 3 (120 req)     |
+| **Total** | **1,000** | **~820** | **~180**  | Reserve for student/testing               |
+
+
+## Round 1 Results (6 broad queries, 50 requests)
+
+All results from Key 1. First ingestion run — zero prior records, so no dedup skips.
+
+| Query Name           | Keywords                                                      | Pages | Staged | Dedup Skipped | Yield | Notes                                          |
+| -------------------- | ------------------------------------------------------------- | ----- | ------ | ------------- | ----- | ---------------------------------------------- |
+| ai-engineering       | AI engineer, machine learning engineer                        | 10    | 78     | 0             | 100%  | Strong AI/ML role coverage                     |
+| data-science         | data scientist, data analyst, data engineer                   | 10    | 89     | 0             | 100%  | Broad data roles, high volume                  |
+| prompt-llm           | prompt engineer, LLM, generative AI                           | 10    | 48     | 0             | 100%  | Good agentic era signal                        |
+| software-engineering | software engineer, backend developer, full stack              | 10    | 95     | 0             | 100%  | Highest volume — broad tech roles              |
+| devops-cloud         | DevOps engineer, cloud architect, platform engineer           | 5     | 42     | 0             | 100%  | Cloud infra roles                              |
+| cybersecurity        | cybersecurity analyst, security engineer                      | 5     | 30     | 0             | 100%  | Security roles baseline                        |
+
+**Round 1 Total: 382 new records from 50 requests (7.64 records/request, zero dedup)**
+
+## Round 2 Results (20 targeted queries, 200 requests)
+
+Key 1 exhausted on first query; all results from Key 2.
+
+### Core AI/ML Roles
+
+
+| Query Name       | Keywords                                              | Staged | Dedup Skipped | Yield | Notes                                                     |
+| ---------------- | ----------------------------------------------------- | ------ | ------------- | ----- | --------------------------------------------------------- |
+| ai-engineering   | AI engineer, machine learning engineer                | 0      | 0             | 0%    | Key 1 429'd; no records                                   |
+| data-science     | data scientist, data analyst                          | 24     | 2             | 92%   | Good yield, broad role coverage                           |
+| prompt-llm       | prompt engineer, LLM, generative AI                   | 2      | 12            | 14%   | High dedup — overlaps with ai-engineering from prior runs |
+| ml-ops           | MLOps engineer, ML infrastructure, model deployment   | 3      | 8             | 27%   | High dedup — niche role, few unique listings              |
+| deep-learning    | deep learning engineer, NLP engineer, computer vision | 12     | 4             | 75%   | Good for specialized AI roles                             |
+| data-engineering | data engineer, data pipeline, ETL developer           | 28     | 0             | 100%  | Excellent — zero dedup, strong pipeline/tooling signals   |
+| ai-research      | AI researcher, applied scientist, research engineer   | 18     | 0             | 100%  | Excellent — no overlap, research-heavy postings           |
+| agentic-ai       | AI agent developer, autonomous systems engineer       | 19     | 0             | 100%  | Excellent — unique niche, zero dedup                      |
+
+
+### Adjacent Tech Roles
+
+
+| Query Name           | Keywords                                                    | Staged | Dedup Skipped | Yield | Notes                                         |
+| -------------------- | ----------------------------------------------------------- | ------ | ------------- | ----- | --------------------------------------------- |
+| software-engineering | software engineer, backend developer                        | 43     | 5             | 90%   | Highest volume core tech query                |
+| full-stack           | full stack developer, full stack engineer                   | 16     | 3             | 84%   | Good volume                                   |
+| python-developer     | Python developer, Python engineer                           | 37     | 0             | 100%  | Strong yield, often includes AI/ML tooling    |
+| devops-cloud         | DevOps engineer, cloud architect, platform engineer         | 3      | 16            | 16%   | High dedup — overlaps with prior runs         |
+| cloud-data           | cloud data engineer, Azure data engineer, AWS data engineer | 19     | 0             | 100%  | Good — cloud + data combo unique              |
+| site-reliability     | site reliability engineer, SRE, infrastructure engineer     | 50     | 0             | 100%  | Max results, zero dedup — very distinct niche |
+| cybersecurity        | cybersecurity analyst, security engineer                    | 1      | 17            | 6%    | Nearly all duplicates from prior runs         |
+
+
+### Emerging/Analytics Roles
+
+
+| Query Name          | Keywords                                                  | Staged | Dedup Skipped | Yield | Notes                                     |
+| ------------------- | --------------------------------------------------------- | ------ | ------------- | ----- | ----------------------------------------- |
+| analytics-bi        | business intelligence analyst, analytics engineer         | 28     | 1             | 97%   | Good volume, BI/analytics tooling signals |
+| solutions-architect | solutions architect, technical architect, cloud solutions | 15     | 0             | 100%  | Clean yield, architecture-level roles     |
+| robotics-automation | robotics engineer, automation engineer                    | 50     | 0             | 100%  | Max results, zero dedup — highly distinct |
+| quant-fintech       | quantitative analyst, fintech engineer                    | 2      | 0             | 100%  | Very niche — few results but all unique   |
+| product-tech        | technical product manager, AI product manager             | 27     | 2             | 93%   | Good for AI product signals               |
+
+
+**Round 2 Total: 397 new records from 200 requests (1.99 records/request after dedup)**
+
+## Round 3 Results (12 additional queries, 120 requests)
+
+Key 1 exhausted on first query; all results from Key 2.
+
+
+| Query Name        | Keywords                                                         | Staged | Dedup Skipped | Yield | Notes                                        |
+| ----------------- | ---------------------------------------------------------------- | ------ | ------------- | ----- | -------------------------------------------- |
+| react-frontend    | React developer, frontend engineer, TypeScript developer         | 0      | 0             | 0%    | Key 1 429'd; no records                      |
+| java-enterprise   | Java developer, Java engineer, Spring Boot developer             | 49     | 1             | 98%   | Very high volume, enterprise tooling         |
+| systems-engineer  | systems engineer, Linux engineer, systems administrator          | 50     | 0             | 100%  | Max results, zero dedup                      |
+| blockchain-web3   | blockchain developer, Web3 engineer, smart contract developer    | 2      | 0             | 100%  | Very niche — few listings                    |
+| data-governance   | data governance analyst, data quality engineer, data steward     | 8      | 0             | 100%  | Niche but clean                              |
+| ai-safety         | AI safety engineer, responsible AI, AI ethics                    | 8      | 0             | 100%  | Niche but 100% unique — good for agentic era |
+| mobile-dev        | mobile developer, iOS developer, Android developer               | 50     | 0             | 100%  | Max results (98 fetched, capped at 50)       |
+| database-engineer | database engineer, DBA, database architect                       | 28     | 0             | 100%  | Good volume                                  |
+| rust-go-modern    | Rust developer, Go developer, Golang engineer                    | 5      | 0             | 100%  | Very niche — few listings                    |
+| ml-scientist      | machine learning scientist, applied ML, ML researcher            | 49     | 1             | 98%   | Excellent for ML research roles              |
+| technical-lead    | technical lead, engineering manager, staff engineer              | 18     | 0             | 100%  | Good for senior-level signals                |
+| platform-engineer | platform engineer, developer experience, internal tools engineer | 19     | 0             | 100%  | Good DevEx/platform signals                  |
+
+
+**Round 3 Total: 286 new records from 120 requests (2.38 records/request after dedup)**
+
+## Top Performers for AI/Agentic Role Coverage
+
+Ranked by value for exercising AI/agentic pipeline features (SOC classification, ESCO taxonomy, temporal period analysis, skill/tool signal density):
+
+### Tier 1 — Best AI/ML signal density
+
+
+| Query             | Staged | Why                                                |
+| ----------------- | ------ | -------------------------------------------------- |
+| **ml-scientist**  | 49     | ML research roles with rich skill taxonomies       |
+| **ai-research**   | 18     | Applied science roles, strong ESCO mapping         |
+| **agentic-ai**    | 19     | Direct agentic era roles, autonomous systems       |
+| **deep-learning** | 12     | NLP/CV specialists, dense tool signals             |
+| **ai-safety**     | 8      | Responsible AI, emerging agentic era roles         |
+| **prompt-llm**    | 2      | High dedup (overlap), but exact target when unique |
+
+
+### Tier 2 — Strong AI-adjacent signal density
+
+
+| Query                    | Staged | Why                                                |
+| ------------------------ | ------ | -------------------------------------------------- |
+| **data-engineering**     | 28     | Pipeline tools (Spark, Airflow, dbt), ETL patterns |
+| **data-science**         | 24     | Broad ML/stats tooling, Python ecosystem           |
+| **python-developer**     | 37     | Often includes ML/AI libraries in requirements     |
+| **cloud-data**           | 19     | Cloud-native data infra (Azure ML, SageMaker)      |
+| **software-engineering** | 43     | Broad tech stack signals, high volume              |
+| **product-tech**         | 27     | AI product management, strategy signals            |
+
+
+### Tier 3 — Volume but lower AI signal
+
+
+| Query                   | Staged | Why                                             |
+| ----------------------- | ------ | ----------------------------------------------- |
+| **site-reliability**    | 50     | Max volume, strong infra tooling but less AI    |
+| **robotics-automation** | 50     | Max volume, good for automation but less LLM/AI |
+| **mobile-dev**          | 50     | Max volume, framework signals but minimal AI    |
+| **systems-engineer**    | 50     | Max volume, Linux/infra but little AI           |
+| **java-enterprise**     | 49     | High volume, enterprise patterns but less AI    |
+
+
+### Tier 4 — Low yield or high dedup
+
+
+| Query               | Staged | Why                                     |
+| ------------------- | ------ | --------------------------------------- |
+| **ml-ops**          | 3      | Niche + high dedup from prior runs      |
+| **devops-cloud**    | 3      | High dedup — "cloud architect" overlaps |
+| **cybersecurity**   | 1      | Nearly all duplicates                   |
+| **quant-fintech**   | 2      | Very niche, few listings                |
+| **blockchain-web3** | 2      | Very niche, few listings                |
+| **rust-go-modern**  | 5      | Niche modern languages                  |
+
+
+## Recommendations for Future Ingestion Runs
+
+1. **Prioritize Tier 1 + Tier 2 queries** for AI/agentic pipeline testing.
+2. **Drop high-dedup queries** (cybersecurity, devops-cloud, ml-ops) unless prior-run records are purged.
+3. **Add date filters** to JSearch queries if the API supports them, to get fresher postings with agentic era signals.
+4. **Rotate keyword variants** between runs: e.g., "generative AI engineer" instead of "AI engineer" to avoid dedup.
+5. **Tier 3 queries are useful for volume** when you need diverse role types for analytics/visualization testing, but contribute less to AI taxonomy coverage.
+

--- a/agents/docs/RUNBOOK.md
+++ b/agents/docs/RUNBOOK.md
@@ -217,7 +217,17 @@ with get_engine().connect() as conn:
 
 ## 7. Full Pipeline Run
 
-Run the complete pipeline (Ingestion → Normalization → stub agents):
+Run the flywheel pipeline (decoupled ingestion + processing):
+
+```bash
+# Loop 1: Ingest from JSearch API
+python agents/scripts/batch_ingest.py
+
+# Loop 2: Process pending records (normalize → extract → enrich)
+python agents/scripts/run_processing_loop.py --batch-size 50 --delay 2
+```
+
+**Demo run** (fixture data only, Week 2 demo):
 
 ```bash
 python agents/pipeline_runner.py

--- a/agents/docs/runbooks/WEEK06_TESTING_RUNBOOK.md
+++ b/agents/docs/runbooks/WEEK06_TESTING_RUNBOOK.md
@@ -71,7 +71,7 @@ Sources (JSearch API + Crawl4AI)
 Decouples ingestion (API budget-constrained) from processing (LLM rate-limit-constrained) via the database as a queue. See issue #161.
 
 ```
-Loop 1: Batch Ingest (batch_ingest_borderplex.py)
+Loop 1: Batch Ingest (batch_ingest.py)
     JSearch API  ──→  raw_ingested_jobs (processing_status='pending')
     (budget-aware, key rotation, ingestion_queries.yaml config)
 
@@ -259,10 +259,10 @@ For production-scale ingestion (500–1,500 records), use the batch ingestion sc
 
 ```bash
 # Preview what will be ingested (no API calls)
-python agents/scripts/batch_ingest_borderplex.py --dry-run
+python agents/scripts/batch_ingest.py --dry-run
 
 # Run all queries from config (with 5s delay between queries)
-python agents/scripts/batch_ingest_borderplex.py --delay 5
+python agents/scripts/batch_ingest.py --delay 5
 ```
 
 The script reads query configuration from `agents/config/ingestion_queries.yaml`, which defines keyword groups (e.g., `react-frontend`, `java-enterprise`, `ml-scientist`) and how many pages to fetch per group.
@@ -404,7 +404,7 @@ The processing loop (`run_processing_loop.py`) is flywheel Loop 2 — it drains 
 | Scenario | Use |
 |----------|-----|
 | Quick demo with <50 records | `pipeline_runner.py` (Option A) |
-| Production run with 500+ records | `batch_ingest_borderplex.py` then `run_processing_loop.py` (Option B) |
+| Production run with 500+ records | `batch_ingest.py` then `run_processing_loop.py` (Option B) |
 | Re-process after code changes | `run_processing_loop.py` only (raw records already staged) |
 
 ### Preview pending work
@@ -484,7 +484,7 @@ For production runs with large record counts:
 
 ```bash
 # Step 1: Bulk ingest (fills the queue)
-python agents/scripts/batch_ingest_borderplex.py --delay 5
+python agents/scripts/batch_ingest.py --delay 5
 
 # Step 2: Verify raw records staged
 python agents/scripts/db_check.py counts
@@ -565,7 +565,7 @@ python agents/scripts/db_check.py reset
 python agents/pipeline_runner.py
 
 # 5b. Option B — Flywheel (production-scale)
-python agents/scripts/batch_ingest_borderplex.py --delay 5
+python agents/scripts/batch_ingest.py --delay 5
 python agents/scripts/run_processing_loop.py --batch-size 50 --delay 2
 
 # 6. Verify populated data

--- a/agents/docs/runbooks/WEEK06_TESTING_RUNBOOK.md
+++ b/agents/docs/runbooks/WEEK06_TESTING_RUNBOOK.md
@@ -32,16 +32,21 @@ source agents/.venv/bin/activate
 6. [Layer 3 — Normalization](#6-layer-3--normalization)
 7. [Layer 4 — Skills Extraction](#7-layer-4--skills-extraction)
 8. [Layer 5 — Enrichment](#8-layer-5--enrichment)
-9. [Layer 6 — Full Pipeline End-to-End](#9-layer-6--full-pipeline-end-to-end)
-10. [Layer 7 — Streamlit Dashboard](#10-layer-7--streamlit-dashboard)
-11. [Cloud DB Demo Setup](#11-cloud-db-demo-setup)
-12. [Troubleshooting](#12-troubleshooting)
+9. [Decoupled Processing Loop](#9-decoupled-processing-loop)
+10. [Full Pipeline End-to-End](#10-full-pipeline-end-to-end)
+11. [Streamlit Dashboard](#11-streamlit-dashboard)
+12. [Cloud DB Demo Setup](#12-cloud-db-demo-setup)
+13. [Troubleshooting](#13-troubleshooting)
 
 ---
 
 ## 1. Overview
 
-The Week 6 pipeline runs 7 Phase 1 agents sequentially:
+The pipeline has two operational modes:
+
+### Option A — Single-pass demo (`pipeline_runner.py`)
+
+Chains all agents in one sequential run. Good for quick demos with small record counts (<50).
 
 ```
 Sources (JSearch API + Crawl4AI)
@@ -60,6 +65,24 @@ Sources (JSearch API + Crawl4AI)
 [Visualization Agent]     → dashboard output
 [Orchestration Agent]     → alert bus monitoring
 ```
+
+### Option B — Flywheel pattern (production, 1K+ jobs)
+
+Decouples ingestion (API budget-constrained) from processing (LLM rate-limit-constrained) via the database as a queue. See issue #161.
+
+```
+Loop 1: Batch Ingest (batch_ingest_borderplex.py)
+    JSearch API  ──→  raw_ingested_jobs (processing_status='pending')
+    (budget-aware, key rotation, ingestion_queries.yaml config)
+
+         ↓  (DB as queue — runs independently)
+
+Loop 2: Paced Processing (run_processing_loop.py)
+    raw_ingested_jobs ──→ [Normalize] ──→ [Extract Skills] ──→ [Enrich]
+    (polls DB, processes in batches, pauses for LLM rate limits)
+```
+
+Loop 1 can fill the queue with 500–1,500 raw records across many role categories. Loop 2 drains the queue at a pace matched to Azure OpenAI rate limits. They run independently — you can re-run Loop 1 to add more records without restarting Loop 2.
 
 ### What each agent writes
 
@@ -106,12 +129,18 @@ AZURE_OPENAI_EMBEDDING_DEPLOYMENT_NAME=embeddings-te3small
 
 # Ingestion sources
 JSEARCH_API_KEY=<rapidapi-key>
+JSEARCH_API_KEY_2=<optional-secondary-key>     # For API key rotation in batch ingestion
 
 # Pipeline thresholds
 SPAM_FLAG_THRESHOLD=0.7
 SPAM_REJECT_THRESHOLD=0.9
 SKILL_CONFIDENCE_THRESHOLD=0.75
 BATCH_SIZE=100
+
+# Flywheel processing loop tuning (adjust to match your Azure OpenAI TPM)
+SKILLS_EXTRACTION_CHUNK_SIZE=50
+SKILLS_EXTRACTION_CHUNK_COOLDOWN=2
+SKILLS_EXTRACTION_DELAY=0.1
 ```
 
 ### Verify your environment
@@ -194,8 +223,8 @@ python agents/scripts/db_check.py query "SELECT column_name FROM information_sch
 ## 5. Layer 2 — Ingestion (JSearch + Crawl4AI)
 
 The Ingestion Agent fetches jobs from two sources:
-- **JSearch API** — RapidAPI, fetches software engineering jobs in El Paso region
-- **Crawl4AI** — scrapes El Paso city government jobs portal
+- **JSearch API** — RapidAPI, fetches jobs across many role categories (AI/ML, DevOps, data science, etc.)
+- **Crawl4AI** — scrapes Borderplex government jobs portals (El Paso, Las Cruces, EPCC)
 
 ### Test ingestion independently
 
@@ -224,6 +253,34 @@ print(f'Key length: {len(key)}')
 "
 ```
 
+### Batch ingestion (flywheel Loop 1)
+
+For production-scale ingestion (500–1,500 records), use the batch ingestion script instead of `pipeline_runner.py`:
+
+```bash
+# Preview what will be ingested (no API calls)
+python agents/scripts/batch_ingest_borderplex.py --dry-run
+
+# Run all queries from config (with 5s delay between queries)
+python agents/scripts/batch_ingest_borderplex.py --delay 5
+```
+
+The script reads query configuration from `agents/config/ingestion_queries.yaml`, which defines keyword groups (e.g., `react-frontend`, `java-enterprise`, `ml-scientist`) and how many pages to fetch per group.
+
+**API key rotation:** Set `JSEARCH_API_KEY` and optionally `JSEARCH_API_KEY_2` in `.env`. The script rotates to the secondary key when the primary key's budget is exhausted or a 429 is received. Free tier: 200 requests/month per key.
+
+### Verify after ingestion
+
+```bash
+python agents/scripts/db_check.py counts
+```
+
+**Expected:** `raw_ingested_jobs` should show 500–1,500 rows depending on query config and API key budget.
+
+### Known issue: empty descriptions (#165)
+
+Approximately 46% of JSearch results arrive with empty `job_description` fields. These records are staged but will be skipped by Skills Extraction (logged as `skills_extraction_no_text`). This is a JSearch API limitation, not a mapping bug. See [issue #165](https://github.com/Building-With-Agents/watechcoalition/issues/165) for backfill solutions.
+
 ---
 
 ## 6. Layer 3 — Normalization
@@ -242,7 +299,33 @@ python agents/scripts/db_check.py query "SELECT COUNT(*) AS total, COUNT(title) 
 
 ## 7. Layer 4 — Skills Extraction
 
-Pass 1 extracts tools via pattern matching (zero cost). Pass 2 extracts skills via LLM (Azure OpenAI). Results go to `extracted_intelligence`. Every LLM call is logged in `llm_audit_log`.
+Pass 1 extracts tools via pattern matching (zero cost). Pass 2 extracts tasks, responsibilities, and skills via LLM (Azure OpenAI). Results go to `extracted_intelligence`. Every LLM call is logged in `llm_audit_log`.
+
+### Rate-limit management
+
+Skills Extraction makes 2–3 LLM calls per job (tasks + responsibilities + skills). With large batches, Azure OpenAI rate limits become the bottleneck. Tune these env vars to match your deployment's TPM/RPM:
+
+```bash
+# Set in .env or as shell env vars before running the processing loop
+SKILLS_EXTRACTION_CHUNK_SIZE=50      # Records per chunk before cooldown
+SKILLS_EXTRACTION_CHUNK_COOLDOWN=2   # Seconds between chunks
+SKILLS_EXTRACTION_DELAY=0.1          # Seconds between records within a chunk
+```
+
+**Check your Azure OpenAI rate limits:**
+
+```bash
+az cognitiveservices account deployment list \
+  --name <your-resource-name> \
+  --resource-group <your-resource-group> \
+  -o table
+```
+
+For 1K+ job batches, set the `chat-gpt41mini` deployment to at least 100K TPM (capacity 100) via the Azure Portal or CLI. See the Troubleshooting section for details.
+
+### Known issue: empty descriptions
+
+Approximately 46% of JSearch records have empty `job_description` fields. These records skip LLM extraction entirely (logged as `skills_extraction_no_text`). Only records with description/requirements/responsibilities text are processed. See [issue #165](https://github.com/Building-With-Agents/watechcoalition/issues/165).
 
 ### Verify after pipeline run
 
@@ -250,9 +333,22 @@ Pass 1 extracts tools via pattern matching (zero cost). Pass 2 extracts skills v
 # Check extraction results
 python agents/scripts/db_check.py query "SELECT COUNT(*) AS total, COUNT(skills) AS has_skills, COUNT(tools) AS has_tools FROM dbo.extracted_intelligence"
 
-# Check LLM costs
-python agents/scripts/db_check.py query "SELECT COUNT(*) AS calls, SUM(prompt_tokens) AS prompt_tok, SUM(completion_tokens) AS comp_tok FROM dbo.llm_audit_log"
+# Check extraction success vs. failure
+python agents/scripts/db_check.py query "SELECT extraction_status, COUNT(*) FROM dbo.extracted_intelligence GROUP BY extraction_status"
+
+# LLM audit — by agent (tasks / responsibilities / skills / taxonomy use distinct names)
+python agents/scripts/db_check.py query "SELECT agent_name, COUNT(*) AS calls, COALESCE(SUM(cost_usd),0) AS usd, COALESCE(SUM(COALESCE(input_tokens,0)+COALESCE(output_tokens,0)),0) AS tokens FROM dbo.llm_audit_log GROUP BY agent_name ORDER BY usd DESC NULLS LAST"
 ```
+
+### Cost projection (1k jobs)
+
+Run the cost report (uses `llm_audit_log`, `extracted_intelligence.extraction_cost_usd`, and description fill rate):
+
+```bash
+python agents/scripts/llm_audit_cost_report.py --project-jobs 1000
+```
+
+It prints per-agent spend, a projection from stored `extraction_cost_usd`, and a second projection from audit totals (usually closer to real LLM spend). `orchestration_audit_log` is for orchestration decisions, not token billing — use `llm_audit_log` for model costs.
 
 ---
 
@@ -299,9 +395,76 @@ python agents/scripts/db_check.py query "SELECT COUNT(*) AS total, COUNT(quality
 
 ---
 
-## 9. Layer 6 — Full Pipeline End-to-End
+## 9. Decoupled Processing Loop
 
-Run the complete pipeline from ingestion through enrichment:
+The processing loop (`run_processing_loop.py`) is flywheel Loop 2 — it drains the queue of pending/unextracted records through Normalization, Skills Extraction, and Enrichment.
+
+### When to use
+
+| Scenario | Use |
+|----------|-----|
+| Quick demo with <50 records | `pipeline_runner.py` (Option A) |
+| Production run with 500+ records | `batch_ingest_borderplex.py` then `run_processing_loop.py` (Option B) |
+| Re-process after code changes | `run_processing_loop.py` only (raw records already staged) |
+
+### Preview pending work
+
+```bash
+python agents/scripts/run_processing_loop.py --dry-run
+```
+
+This shows pending raw records, unextracted normalized records, enriched job postings, and estimated iterations/time.
+
+### Run the processing loop
+
+```bash
+# Default: batch-size 50, 10s delay between iterations
+python agents/scripts/run_processing_loop.py
+
+# Faster (requires sufficient Azure OpenAI TPM):
+python agents/scripts/run_processing_loop.py --batch-size 50 --delay 2
+
+# Limit to 5 iterations (for testing):
+python agents/scripts/run_processing_loop.py --max-iterations 5 --batch-size 25
+```
+
+**For faster throughput**, set the extraction chunk env vars before running:
+
+```powershell
+$env:SKILLS_EXTRACTION_CHUNK_SIZE="50"
+$env:SKILLS_EXTRACTION_CHUNK_COOLDOWN="2"
+$env:SKILLS_EXTRACTION_DELAY="0.1"
+python agents/scripts/run_processing_loop.py --batch-size 50 --delay 2
+```
+
+### Monitoring progress
+
+The loop emits structured JSON logs. Key events to watch:
+
+| Event | Meaning |
+|-------|---------|
+| `iteration_start` | New iteration; shows `pending_raw` and `unextracted` counts |
+| `skills_extraction_no_text` | Job skipped (empty description) |
+| `tasks_extraction_complete` | LLM extracted tasks for one job |
+| `responsibilities_extraction_complete` | LLM extracted responsibilities for one job |
+| `iteration_complete` | Iteration done; shows `remaining_raw`, `remaining_unextracted`, `total_enriched` |
+| `all_records_processed` | Queue fully drained |
+| `*_llm_failed` with `429` | Rate limit hit — increase Azure OpenAI TPM or slow down |
+
+### Stop conditions
+
+The loop exits when:
+- No pending raw records AND no unextracted normalized records
+- `--max-iterations` reached
+- No progress (0 records normalized and 0 extracted in an iteration)
+
+---
+
+## 10. Full Pipeline End-to-End
+
+### Option A — Single-pass demo (small batches)
+
+For quick demos with <50 records:
 
 ```bash
 python agents/pipeline_runner.py
@@ -313,7 +476,27 @@ The pipeline runner:
 3. Chains each agent's output as the next agent's input
 4. Writes a run log to `agents/data/output/pipeline_run.json`
 
-**Estimated runtime:** 10-25 minutes depending on record count and LLM latency.
+**Estimated runtime:** 10-25 minutes for ~10-50 records.
+
+### Option B — Flywheel (production-scale, 500+ records)
+
+For production runs with large record counts:
+
+```bash
+# Step 1: Bulk ingest (fills the queue)
+python agents/scripts/batch_ingest_borderplex.py --delay 5
+
+# Step 2: Verify raw records staged
+python agents/scripts/db_check.py counts
+
+# Step 3: Preview processing work
+python agents/scripts/run_processing_loop.py --dry-run
+
+# Step 4: Run paced processing
+python agents/scripts/run_processing_loop.py --batch-size 50 --delay 2
+```
+
+**Estimated runtime:** 2-6 hours for ~1,000 records (depends on Azure OpenAI rate limits and how many records have descriptions). See [issue #166](https://github.com/Building-With-Agents/watechcoalition/issues/166) for planned parallelism improvements.
 
 ### Verify complete run
 
@@ -321,15 +504,15 @@ The pipeline runner:
 # Row counts across all tables
 python agents/scripts/db_check.py counts
 
-# Check pipeline run log
-python -c "import json; data = json.load(open('agents/data/output/pipeline_run.json')); print(f'Stages: {len(data)}')"
+# Check enrichment output
+python agents/scripts/db_check.py query "SELECT COUNT(*) AS enriched_jobs FROM dbo.job_postings"
 ```
 
-**Expected:** All pipeline tables populated. Run log should show 7+ stage entries.
+**Expected (Option A):** 10-50 records across pipeline tables. **Expected (Option B):** 500-1,500 raw records; ~54% with descriptions processed through extraction and enrichment.
 
 ---
 
-## 10. Layer 7 — Streamlit Dashboard
+## 11. Streamlit Dashboard
 
 The dashboard reads from the same database via a read-only SQLAlchemy engine.
 
@@ -352,7 +535,7 @@ streamlit run dashboard/streamlit_app.py
 
 ---
 
-## 11. Cloud DB Demo Setup
+## 12. Cloud DB Demo Setup
 
 Use this to populate the shared cloud database before demo day. Students connect to the same data without running the pipeline locally.
 
@@ -378,14 +561,20 @@ python agents/scripts/db_check.py counts
 # 4. Reset pipeline tables (clean slate — no dups, no short-circuiting)
 python agents/scripts/db_check.py reset
 
-# 5. Run full pipeline against cloud DB
+# 5a. Option A — Single-pass demo (small batch)
 python agents/pipeline_runner.py
+
+# 5b. Option B — Flywheel (production-scale)
+python agents/scripts/batch_ingest_borderplex.py --delay 5
+python agents/scripts/run_processing_loop.py --batch-size 50 --delay 2
 
 # 6. Verify populated data
 python agents/scripts/db_check.py counts
 ```
 
 ### Expected results after pipeline run
+
+**Option A (pipeline_runner.py):**
 
 | Table | Expected |
 |-------|----------|
@@ -397,6 +586,19 @@ python agents/scripts/db_check.py counts
 | job_postings | ~same as normalized (promoted records) |
 | employer_profiles | 0 (SOC/NAICS not yet merged) |
 | llm_audit_log | cumulative (preserved across resets) |
+
+**Option B (flywheel):**
+
+| Table | Expected |
+|-------|----------|
+| job_ingestion_runs | 20-50 (one per query in ingestion_queries.yaml) |
+| raw_ingested_jobs | 500-1,500 (across many role categories) |
+| normalized_jobs | ~same as raw |
+| normalization_quarantine | 0-10 |
+| extracted_intelligence | ~54% of normalized (records with descriptions) |
+| job_postings | ~same as extracted_intelligence |
+| employer_profiles | 0 (SOC/NAICS not yet merged) |
+| llm_audit_log | cumulative; 2-3 calls per extracted record |
 
 ### Student setup for demo day
 
@@ -413,7 +615,7 @@ Students can then:
 
 ---
 
-## 12. Troubleshooting
+## 13. Troubleshooting
 
 ### Database connection failures
 
@@ -466,3 +668,53 @@ UndefinedTable: relation "dbo.extracted_intelligence" does not exist
 - `temporal_period`: requires `date_posted` on the job posting — null if date missing
 - `borderplex_subregion`: requires location data — null if location missing from source
 - `is_duplicate`: will be FALSE for first run (no prior records to compare against)
+
+### Azure OpenAI 429 rate limits (Skills Extraction)
+
+```
+Error code: 429 - {'error': {'message': 'Too Many Requests'}}
+```
+
+Your Azure OpenAI deployment's TPM (tokens per minute) is too low for the extraction throughput. To check and increase:
+
+```bash
+# Check current deployments and rate limits
+az cognitiveservices account deployment list \
+  --name <your-resource-name> \
+  --resource-group <your-resource-group> \
+  -o json
+
+# Increase gpt-4.1-mini to 100K TPM (capacity=100)
+az cognitiveservices account deployment create \
+  --name <your-resource-name> \
+  --resource-group <your-resource-group> \
+  --deployment-name chat-gpt41mini \
+  --model-name gpt-4.1-mini \
+  --model-version "2025-04-14" \
+  --model-format OpenAI \
+  --sku-capacity 100 \
+  --sku-name Standard
+```
+
+Alternatively, slow down extraction by increasing cooldown env vars:
+
+```bash
+SKILLS_EXTRACTION_CHUNK_SIZE=5
+SKILLS_EXTRACTION_CHUNK_COOLDOWN=30
+SKILLS_EXTRACTION_DELAY=1.0
+```
+
+### Empty descriptions from JSearch
+
+Many `skills_extraction_no_text` warnings in the processing loop output indicate JSearch returned metadata-only listings without descriptions. This affects approximately 46% of records. See [issue #165](https://github.com/Building-With-Agents/watechcoalition/issues/165). These records are skipped by Skills Extraction — this is expected behavior, not an error.
+
+### Processing loop exits with "no_progress"
+
+The loop exits when an iteration produces 0 normalized records AND 0 extracted records. This can happen when:
+
+- All remaining raw records are already normalized (pending=0) and all normalized records have already been extracted (unextracted=0) — this is the normal completion path
+- All remaining unextracted records have empty descriptions and were skipped — the loop sees "0 extracted" and exits. Re-run with `--dry-run` to check if unextracted records remain; if they do but all lack descriptions, this is expected
+
+### Processing loop killed or interrupted
+
+The processing loop can be safely interrupted (Ctrl+C) and restarted. It polls the database for pending work on each iteration, so no records are lost. Records that were mid-extraction when interrupted may need to be re-processed — the loop will pick them up on the next run since they will still show as unextracted in the database.

--- a/agents/eval/full_pipeline_redis_metrics.html
+++ b/agents/eval/full_pipeline_redis_metrics.html
@@ -26,25 +26,25 @@
 </head>
 <body>
   <h1>Full pipeline Redis — Run report</h1>
-  <p>Correlation ID: <code>redis-pipe-4ceea103</code></p>
-  <p class="e2e">End-to-end latency: <strong>None ms</strong> | Overall: <strong class="error">Failure</strong></p>
-  <p class="error">Redis error: Redis connection failed: Error 61 connecting to localhost:6379. Connection refused.</p>
+  <p>Correlation ID: <code>redis-pipe-cd457f5d</code></p>
+  <p class="e2e">End-to-end latency: <strong>43535.47 ms</strong> | Overall: <strong class="ok">Success</strong></p>
+  
 
   <h2>Timeline (locate the failing stage)</h2>
   <div class="timeline" role="list">
-<div class="step skipped"><span class="step-name">ingestion</span><span class="step-ms">—</span><span class="step-status">skipped</span></div>
+<div class="step ok"><span class="step-name">ingestion</span><span class="step-ms">25109.83 ms</span><span class="step-status">OK</span></div>
     <div class="arrow" aria-hidden="true">→</div>
-    <div class="step skipped"><span class="step-name">normalization</span><span class="step-ms">—</span><span class="step-status">skipped</span></div>
+    <div class="step ok"><span class="step-name">normalization</span><span class="step-ms">80.53 ms</span><span class="step-status">OK</span></div>
     <div class="arrow" aria-hidden="true">→</div>
-    <div class="step skipped"><span class="step-name">skills</span><span class="step-ms">—</span><span class="step-status">skipped</span></div>
+    <div class="step ok"><span class="step-name">skills</span><span class="step-ms">11.65 ms</span><span class="step-status">OK</span></div>
     <div class="arrow" aria-hidden="true">→</div>
-    <div class="step skipped"><span class="step-name">enrichment</span><span class="step-ms">—</span><span class="step-status">skipped</span></div>
+    <div class="step ok"><span class="step-name">enrichment</span><span class="step-ms">7.63 ms</span><span class="step-status">OK</span></div>
     <div class="arrow" aria-hidden="true">→</div>
-    <div class="step skipped"><span class="step-name">analytics</span><span class="step-ms">—</span><span class="step-status">skipped</span></div>
+    <div class="step ok"><span class="step-name">analytics</span><span class="step-ms">0.36 ms</span><span class="step-status">OK</span></div>
     <div class="arrow" aria-hidden="true">→</div>
-    <div class="step skipped"><span class="step-name">visualization</span><span class="step-ms">—</span><span class="step-status">skipped</span></div>
+    <div class="step ok"><span class="step-name">visualization</span><span class="step-ms">0.05 ms</span><span class="step-status">OK</span></div>
     <div class="arrow" aria-hidden="true">→</div>
-    <div class="step skipped"><span class="step-name">orchestration</span><span class="step-ms">—</span><span class="step-status">skipped</span></div>
+    <div class="step ok"><span class="step-name">orchestration</span><span class="step-ms">0.05 ms</span><span class="step-status">OK</span></div>
   </div>
 
   <h2>Per-stage details</h2>
@@ -52,6 +52,90 @@
     <thead><tr><th>Stage</th><th>Event in → out</th><th>Latency</th><th>Status</th><th>Error</th></tr></thead>
     <tbody>
 
+    <tr class="">
+      <td>ingestion</td>
+      <td>PipelineTrigger → IngestBatch</td>
+      <td>25109.83 ms</td>
+      <td>OK</td>
+      <td></td>
+    </tr>
+    <tr class="">
+      <td>normalization</td>
+      <td>IngestBatch → NormalizationComplete</td>
+      <td>80.53 ms</td>
+      <td>OK</td>
+      <td></td>
+    </tr>
+    <tr class="">
+      <td>skills</td>
+      <td>NormalizationComplete → SkillsExtracted</td>
+      <td>11.65 ms</td>
+      <td>OK</td>
+      <td></td>
+    </tr>
+    <tr class="">
+      <td>skills</td>
+      <td>NormalizationComplete → SkillsExtracted</td>
+      <td>18057.93 ms</td>
+      <td>OK</td>
+      <td></td>
+    </tr>
+    <tr class="">
+      <td>enrichment</td>
+      <td>SkillsExtracted → RecordEnriched</td>
+      <td>7.63 ms</td>
+      <td>OK</td>
+      <td></td>
+    </tr>
+    <tr class="">
+      <td>enrichment</td>
+      <td>SkillsExtracted → RecordEnriched</td>
+      <td>75.36 ms</td>
+      <td>OK</td>
+      <td></td>
+    </tr>
+    <tr class="">
+      <td>analytics</td>
+      <td>RecordEnriched → AnalyticsRefreshed</td>
+      <td>0.36 ms</td>
+      <td>OK</td>
+      <td></td>
+    </tr>
+    <tr class="">
+      <td>analytics</td>
+      <td>RecordEnriched → AnalyticsRefreshed</td>
+      <td>0.05 ms</td>
+      <td>OK</td>
+      <td></td>
+    </tr>
+    <tr class="">
+      <td>visualization</td>
+      <td>AnalyticsRefreshed → RenderComplete</td>
+      <td>0.05 ms</td>
+      <td>OK</td>
+      <td></td>
+    </tr>
+    <tr class="">
+      <td>visualization</td>
+      <td>AnalyticsRefreshed → RenderComplete</td>
+      <td>0.06 ms</td>
+      <td>OK</td>
+      <td></td>
+    </tr>
+    <tr class="">
+      <td>orchestration</td>
+      <td>RenderComplete → OrchestrationAck</td>
+      <td>0.05 ms</td>
+      <td>OK</td>
+      <td></td>
+    </tr>
+    <tr class="">
+      <td>orchestration</td>
+      <td>RenderComplete → OrchestrationAck</td>
+      <td>0.03 ms</td>
+      <td>OK</td>
+      <td></td>
+    </tr>
     </tbody>
   </table>
 
@@ -59,7 +143,13 @@
   <table>
     <thead><tr><th>Stream</th><th>Published</th><th>Delivered</th><th>In flight</th><th>Max in flight</th></tr></thead>
     <tbody>
-    <tr><td colspan="5">No counters (run failed before publish).</td></tr>
+    <tr><td><code>pipeline:ingestion</code></td><td>1</td><td>1</td><td>0</td><td>1</td></tr>
+    <tr><td><code>pipeline:normalization</code></td><td>1</td><td>1</td><td>0</td><td>1</td></tr>
+    <tr><td><code>pipeline:skills</code></td><td>1</td><td>2</td><td>0</td><td>1</td></tr>
+    <tr><td><code>pipeline:enrichment</code></td><td>2</td><td>2</td><td>0</td><td>1</td></tr>
+    <tr><td><code>pipeline:analytics</code></td><td>2</td><td>2</td><td>0</td><td>1</td></tr>
+    <tr><td><code>pipeline:visualization</code></td><td>2</td><td>2</td><td>0</td><td>1</td></tr>
+    <tr><td><code>pipeline:orchestration</code></td><td>2</td><td>2</td><td>0</td><td>1</td></tr>
     </tbody>
   </table>
 </body>

--- a/agents/eval/full_pipeline_redis_metrics.json
+++ b/agents/eval/full_pipeline_redis_metrics.json
@@ -1,8 +1,277 @@
 {
-  "success": false,
-  "error": "Redis connection failed: Error 61 connecting to localhost:6379. Connection refused.",
-  "correlation_id": "redis-pipe-4ceea103",
-  "stages": [],
-  "e2e_latency_ms": null,
-  "run_start_iso": "2026-04-01T21:35:21.308161+00:00"
+  "success": true,
+  "correlation_id": "redis-pipe-cd457f5d",
+  "stages": [
+    {
+      "stage": "ingestion",
+      "event_type_in": "PipelineTrigger",
+      "event_type_out": "IngestBatch",
+      "event_id_out": "0143cc6e-d464-43f3-8c5a-bea55b8d6cc9",
+      "start_ts": "2026-04-03T00:41:58.330846+00:00",
+      "end_ts": "2026-04-03T00:42:23.440527+00:00",
+      "latency_ms": 25109.83,
+      "success": true,
+      "error": null,
+      "payload_summary": {
+        "event_type": "IngestBatch",
+        "batch_id": "c956ec3c-214a-4b64-8758-608021aa9894",
+        "job_ids": null
+      }
+    },
+    {
+      "stage": "normalization",
+      "event_type_in": "IngestBatch",
+      "event_type_out": "NormalizationComplete",
+      "event_id_out": "99d024c4-9e39-43a4-8d35-0acc38d6b0bf",
+      "start_ts": "2026-04-03T00:42:23.444035+00:00",
+      "end_ts": "2026-04-03T00:42:23.524754+00:00",
+      "latency_ms": 80.53,
+      "success": true,
+      "error": null,
+      "payload_summary": {
+        "event_type": "NormalizationComplete",
+        "batch_id": "c956ec3c-214a-4b64-8758-608021aa9894",
+        "job_ids": null
+      }
+    },
+    {
+      "stage": "skills",
+      "event_type_in": "NormalizationComplete",
+      "event_type_out": "SkillsExtracted",
+      "event_id_out": "8e86342c-e7f7-405b-a4fb-3418001e0cf8",
+      "start_ts": "2026-04-03T00:42:23.527767+00:00",
+      "end_ts": "2026-04-03T00:42:23.539306+00:00",
+      "latency_ms": 11.65,
+      "success": true,
+      "error": null,
+      "payload_summary": {
+        "event_type": "SkillsExtracted",
+        "batch_id": "0a9402f4-129d-47ba-b754-de2a6bcfb914",
+        "job_ids": []
+      }
+    },
+    {
+      "stage": "skills",
+      "event_type_in": "NormalizationComplete",
+      "event_type_out": "SkillsExtracted",
+      "event_id_out": "1c0de3a4-d8a7-4ec7-b61e-f062f473219f",
+      "start_ts": "2026-04-03T00:42:23.542306+00:00",
+      "end_ts": "2026-04-03T00:42:41.600212+00:00",
+      "latency_ms": 18057.93,
+      "success": true,
+      "error": null,
+      "payload_summary": {
+        "event_type": "SkillsExtracted",
+        "batch_id": "c956ec3c-214a-4b64-8758-608021aa9894",
+        "job_ids": [
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13
+        ]
+      }
+    },
+    {
+      "stage": "enrichment",
+      "event_type_in": "SkillsExtracted",
+      "event_type_out": "RecordEnriched",
+      "event_id_out": "e324dc5e-d4a0-4c9b-aa37-2cece5a75649",
+      "start_ts": "2026-04-03T00:42:41.604228+00:00",
+      "end_ts": "2026-04-03T00:42:41.612244+00:00",
+      "latency_ms": 7.63,
+      "success": true,
+      "error": null,
+      "payload_summary": {
+        "event_type": "RecordEnriched",
+        "batch_id": null,
+        "job_ids": null
+      }
+    },
+    {
+      "stage": "enrichment",
+      "event_type_in": "SkillsExtracted",
+      "event_type_out": "RecordEnriched",
+      "event_id_out": "2dd11cd6-583d-457e-b088-a5c8c6aed220",
+      "start_ts": "2026-04-03T00:42:41.613250+00:00",
+      "end_ts": "2026-04-03T00:42:41.688287+00:00",
+      "latency_ms": 75.36,
+      "success": true,
+      "error": null,
+      "payload_summary": {
+        "event_type": "RecordEnriched",
+        "batch_id": "c956ec3c-214a-4b64-8758-608021aa9894",
+        "job_ids": null
+      }
+    },
+    {
+      "stage": "analytics",
+      "event_type_in": "RecordEnriched",
+      "event_type_out": "AnalyticsRefreshed",
+      "event_id_out": "6b4eaf92-6f00-4e99-9512-bd6d36964f51",
+      "start_ts": "2026-04-03T00:42:41.691298+00:00",
+      "end_ts": "2026-04-03T00:42:41.691797+00:00",
+      "latency_ms": 0.36,
+      "success": true,
+      "error": null,
+      "payload_summary": {
+        "event_type": "AnalyticsRefreshed",
+        "batch_id": null,
+        "job_ids": null
+      }
+    },
+    {
+      "stage": "analytics",
+      "event_type_in": "RecordEnriched",
+      "event_type_out": "AnalyticsRefreshed",
+      "event_id_out": "0ef17090-8ff5-4dc0-a9fb-745eae2ab270",
+      "start_ts": "2026-04-03T00:42:41.692798+00:00",
+      "end_ts": "2026-04-03T00:42:41.692798+00:00",
+      "latency_ms": 0.05,
+      "success": true,
+      "error": null,
+      "payload_summary": {
+        "event_type": "AnalyticsRefreshed",
+        "batch_id": null,
+        "job_ids": null
+      }
+    },
+    {
+      "stage": "visualization",
+      "event_type_in": "AnalyticsRefreshed",
+      "event_type_out": "RenderComplete",
+      "event_id_out": "c09ac93e-5396-4fbf-8be7-9a3c2d5c28c0",
+      "start_ts": "2026-04-03T00:42:41.694799+00:00",
+      "end_ts": "2026-04-03T00:42:41.694799+00:00",
+      "latency_ms": 0.05,
+      "success": true,
+      "error": null,
+      "payload_summary": {
+        "event_type": "RenderComplete",
+        "batch_id": null,
+        "job_ids": null
+      }
+    },
+    {
+      "stage": "visualization",
+      "event_type_in": "AnalyticsRefreshed",
+      "event_type_out": "RenderComplete",
+      "event_id_out": "4cca20da-707e-4136-adc7-18eb1e45551b",
+      "start_ts": "2026-04-03T00:42:41.696309+00:00",
+      "end_ts": "2026-04-03T00:42:41.696309+00:00",
+      "latency_ms": 0.06,
+      "success": true,
+      "error": null,
+      "payload_summary": {
+        "event_type": "RenderComplete",
+        "batch_id": null,
+        "job_ids": null
+      }
+    },
+    {
+      "stage": "orchestration",
+      "event_type_in": "RenderComplete",
+      "event_type_out": "OrchestrationAck",
+      "event_id_out": "fe5f126a-8c94-428d-be7b-0fb026a2b5fe",
+      "start_ts": "2026-04-03T00:42:41.699814+00:00",
+      "end_ts": "2026-04-03T00:42:41.699814+00:00",
+      "latency_ms": 0.05,
+      "success": true,
+      "error": null,
+      "payload_summary": {
+        "event_type": "OrchestrationAck",
+        "batch_id": null,
+        "job_ids": null
+      }
+    },
+    {
+      "stage": "orchestration",
+      "event_type_in": "RenderComplete",
+      "event_type_out": "OrchestrationAck",
+      "event_id_out": "577037fa-624a-45c8-a714-4353853ff3e8",
+      "start_ts": "2026-04-03T00:42:41.700315+00:00",
+      "end_ts": "2026-04-03T00:42:41.700315+00:00",
+      "latency_ms": 0.03,
+      "success": true,
+      "error": null,
+      "payload_summary": {
+        "event_type": "OrchestrationAck",
+        "batch_id": "c956ec3c-214a-4b64-8758-608021aa9894",
+        "job_ids": null
+      }
+    }
+  ],
+  "e2e_latency_ms": 43535.47,
+  "run_start_iso": "2026-04-03T00:42:41.700815+00:00",
+  "redis_url_used": "(set)",
+  "counters": {
+    "pipeline:ingestion": {
+      "published_events": 1,
+      "delivered_events": 1,
+      "handler_failures": 0,
+      "queue_depth": 0,
+      "in_flight": 0,
+      "max_queue_depth_seen": 1,
+      "max_in_flight_seen": 1
+    },
+    "pipeline:normalization": {
+      "published_events": 1,
+      "delivered_events": 1,
+      "handler_failures": 0,
+      "queue_depth": 0,
+      "in_flight": 0,
+      "max_queue_depth_seen": 1,
+      "max_in_flight_seen": 1
+    },
+    "pipeline:skills": {
+      "published_events": 1,
+      "delivered_events": 2,
+      "handler_failures": 0,
+      "queue_depth": 0,
+      "in_flight": 0,
+      "max_queue_depth_seen": 1,
+      "max_in_flight_seen": 1
+    },
+    "pipeline:enrichment": {
+      "published_events": 2,
+      "delivered_events": 2,
+      "handler_failures": 0,
+      "queue_depth": 0,
+      "in_flight": 0,
+      "max_queue_depth_seen": 2,
+      "max_in_flight_seen": 1
+    },
+    "pipeline:analytics": {
+      "published_events": 2,
+      "delivered_events": 2,
+      "handler_failures": 0,
+      "queue_depth": 0,
+      "in_flight": 0,
+      "max_queue_depth_seen": 2,
+      "max_in_flight_seen": 1
+    },
+    "pipeline:visualization": {
+      "published_events": 2,
+      "delivered_events": 2,
+      "handler_failures": 0,
+      "queue_depth": 0,
+      "in_flight": 0,
+      "max_queue_depth_seen": 2,
+      "max_in_flight_seen": 1
+    },
+    "pipeline:orchestration": {
+      "published_events": 2,
+      "delivered_events": 2,
+      "handler_failures": 0,
+      "queue_depth": 0,
+      "in_flight": 0,
+      "max_queue_depth_seen": 2,
+      "max_in_flight_seen": 1
+    }
+  }
 }

--- a/agents/ingestion/agent.py
+++ b/agents/ingestion/agent.py
@@ -237,6 +237,7 @@ def stage_records(state: IngestionState) -> IngestionState:
                     city=record.city,
                     state=record.state,
                     country=record.country,
+                    zip_code=record.zip_code,
                     is_remote=record.is_remote,
                     job_url=record.job_url,
                     source_url=record.source_url or None,

--- a/agents/ingestion/sources/jsearch_adapter.py
+++ b/agents/ingestion/sources/jsearch_adapter.py
@@ -73,6 +73,7 @@ def _job_to_raw_record(job: dict, region_id: str) -> RawJobRecord:
     city = job.get("job_city")
     state = job.get("job_state") or job.get("job_state_code")
     country = job.get("job_country")
+    zip_code = job.get("job_zip_code") or job.get("job_postal_code")
     is_remote = job.get("job_is_remote")
     if is_remote is not None and not isinstance(is_remote, bool):
         is_remote = str(is_remote).lower() in ("true", "1", "yes")
@@ -115,6 +116,7 @@ def _job_to_raw_record(job: dict, region_id: str) -> RawJobRecord:
         city=city[:255] if isinstance(city, str) else None,
         state=state[:100] if isinstance(state, str) else None,
         country=country[:10] if isinstance(country, str) else None,
+        zip_code=str(zip_code)[:10] if zip_code else None,
         is_remote=is_remote,
         date_posted=date_posted,
         salary_raw=str(salary_raw)[:255] if salary_raw is not None else None,

--- a/agents/normalization/agent.py
+++ b/agents/normalization/agent.py
@@ -12,6 +12,7 @@ Consumes: IngestBatch
 
 from __future__ import annotations
 
+import os
 import uuid
 
 import structlog
@@ -61,13 +62,20 @@ def initialize_run(state: NormalizationState) -> NormalizationState:
 
 
 def fetch_pending_records(state: NormalizationState) -> NormalizationState:
-    """Query the DB for raw records with processing_status='pending'."""
+    """Query the DB for raw records with processing_status='pending'.
+
+    Supports batch-limited FIFO processing via NORM_BATCH_SIZE env var.
+    When set, fetches at most N records ordered by created_at (oldest first).
+    When unset or 0, fetches all pending records (legacy behavior).
+    """
     ingestion_run_id = state.get("ingestion_run_id", "")
     batch_id = state.get("batch_id", "")
 
     if not check_db_connection():
         log.warning("normalization_no_db", batch_id=batch_id)
         return {"_pending_records": []}  # type: ignore[typeddict-unknown-key]
+
+    batch_size = int(os.environ.get("NORM_BATCH_SIZE", "0"))
 
     try:
         with session_scope() as session:
@@ -76,6 +84,10 @@ def fetch_pending_records(state: NormalizationState) -> NormalizationState:
             )
             if ingestion_run_id:
                 query = query.filter(RawIngestedJob.ingestion_run_id == ingestion_run_id)
+
+            query = query.order_by(RawIngestedJob.created_at.asc())
+            if batch_size > 0:
+                query = query.limit(batch_size)
 
             raw_rows = query.all()
 
@@ -96,6 +108,7 @@ def fetch_pending_records(state: NormalizationState) -> NormalizationState:
                         "city": r.city,
                         "state": r.state,
                         "country": r.country,
+                        "zip_code": r.zip_code,
                         "is_remote": r.is_remote,
                         "job_url": r.job_url,
                         "source_url": r.source_url,
@@ -158,6 +171,7 @@ def normalize_records(state: NormalizationState) -> NormalizationState:
                     city=raw_dict.get("city"),
                     state=raw_dict.get("state"),
                     country=raw_dict.get("country"),
+                    zip_code=raw_dict.get("zip_code"),
                     is_remote=raw_dict.get("is_remote"),
                     date_posted=raw_dict.get("date_posted"),
                     job_url=raw_dict.get("job_url"),
@@ -193,6 +207,7 @@ def normalize_records(state: NormalizationState) -> NormalizationState:
                     city=job_record.city,
                     state_province=job_record.state_province,
                     country=job_record.country,
+                    zip_code=job_record.zip_code,
                     work_arrangement=job_record.work_arrangement,
                     is_remote=job_record.is_remote,
                     job_url=job_record.job_url,

--- a/agents/normalization/mappers/jsearch_mapper.py
+++ b/agents/normalization/mappers/jsearch_mapper.py
@@ -1,10 +1,55 @@
-"""JSearch field mapper — RawJobRecord (jsearch) to canonical JobRecord."""
+"""JSearch field mapper — RawJobRecord (jsearch) to canonical JobRecord.
+
+Zip code resolution: if the posting includes a zip_code, pass it through.
+If not but city+state are available, look up postal_geo_data by city+state_code
+to resolve the zip. County and other geo data are always looked up via JOIN
+to postal_geo_data at query time, never stored on the job record.
+"""
 
 from __future__ import annotations
+
+import structlog
 
 from agents.common.types.job_record import JobRecord
 from agents.common.types.raw_job_record import RawJobRecord
 from agents.normalization.mappers.base import MapperBase
+
+log = structlog.get_logger()
+
+
+def _resolve_zip_code(city: str | None, state: str | None, raw_zip: str | None) -> str | None:
+    """Resolve zip code: use raw value if available, else look up postal_geo_data."""
+    if raw_zip:
+        return raw_zip.strip()[:10]
+
+    if not city or not state:
+        return None
+
+    try:
+        from agents.common.data_store.database import check_db_connection, session_scope
+        from agents.common.data_store.models import PostalGeoData
+
+        if not check_db_connection():
+            return None
+
+        city_clean = city.strip().lower()
+        state_clean = state.strip().upper()[:2]
+
+        with session_scope() as session:
+            match = (
+                session.query(PostalGeoData.zip)
+                .filter(
+                    PostalGeoData.state_code == state_clean,
+                    PostalGeoData.city.ilike(city_clean),
+                )
+                .first()
+            )
+            if match:
+                return match.zip
+    except Exception as exc:
+        log.debug("zip_resolution_failed", city=city, state=state, error=str(exc))
+
+    return None
 
 
 class JSearchMapper(MapperBase):
@@ -16,6 +61,8 @@ class JSearchMapper(MapperBase):
 
     def map(self, raw: RawJobRecord) -> JobRecord:
         """Transform a RawJobRecord from JSearch into a JobRecord."""
+        zip_code = _resolve_zip_code(raw.city, raw.state, raw.zip_code)
+
         return JobRecord(
             raw_job_id=0,
             ingestion_run_id="",
@@ -29,6 +76,7 @@ class JSearchMapper(MapperBase):
             city=raw.city,
             state_province=raw.state,
             country=raw.country,
+            zip_code=zip_code,
             work_arrangement=None,
             is_remote=raw.is_remote,
             date_posted=raw.date_posted,

--- a/agents/pipeline_runner.py
+++ b/agents/pipeline_runner.py
@@ -1,10 +1,12 @@
 """
-Pipeline Runner — Week 3 Batch-Oriented.
+Pipeline Runner — Demo Run (Week 2 fixture data only).
 
-Sends a batch trigger to the Ingestion Agent, which fetches its own data.
-The Normalization Agent reads staged records from the DB.
-Downstream agents (Skills Extraction through Orchestration) are still stubs
-that pass through the upstream event.
+DEPRECATED for production use. Use the flywheel pipeline instead:
+  - Loop 1 (ingest):  python agents/scripts/batch_ingest.py
+  - Loop 2 (process): python agents/scripts/run_processing_loop.py
+
+This script runs all agents sequentially in a single pass with fixture data.
+Kept for Week 2 walking skeleton demos and test_pipeline_runner.py.
 
 Usage (from the repo root):
     python agents/pipeline_runner.py

--- a/agents/pyproject.toml
+++ b/agents/pyproject.toml
@@ -32,8 +32,8 @@ ignore = [
 "scripts/dedup_metrics_report.py" = ["T201"]
 "agents/scripts/ingest_duplicate_demo.py" = ["T201"]
 "scripts/ingest_duplicate_demo.py" = ["T201"]
-"agents/scripts/batch_ingest_borderplex.py" = ["T201"]
-"scripts/batch_ingest_borderplex.py" = ["T201"]
+"agents/scripts/batch_ingest.py" = ["T201"]
+"scripts/batch_ingest.py" = ["T201"]
 "agents/scripts/run_processing_loop.py" = ["T201"]
 "scripts/run_processing_loop.py" = ["T201"]
 

--- a/agents/pyproject.toml
+++ b/agents/pyproject.toml
@@ -32,6 +32,10 @@ ignore = [
 "scripts/dedup_metrics_report.py" = ["T201"]
 "agents/scripts/ingest_duplicate_demo.py" = ["T201"]
 "scripts/ingest_duplicate_demo.py" = ["T201"]
+"agents/scripts/batch_ingest_borderplex.py" = ["T201"]
+"scripts/batch_ingest_borderplex.py" = ["T201"]
+"agents/scripts/run_processing_loop.py" = ["T201"]
+"scripts/run_processing_loop.py" = ["T201"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["agents"]

--- a/agents/requirements.txt
+++ b/agents/requirements.txt
@@ -20,3 +20,4 @@ thefuzz>=0.22
 ruff>=0.4
 matplotlib>=3.8
 rapidfuzz>=3.0
+pyyaml>=6.0

--- a/agents/scripts/batch_ingest.py
+++ b/agents/scripts/batch_ingest.py
@@ -10,9 +10,9 @@ Prerequisites:
   - PYTHON_DATABASE_URL for database staging
 
 Usage (from repo root):
-  python agents/scripts/batch_ingest_borderplex.py                # run all queries
-  python agents/scripts/batch_ingest_borderplex.py --dry-run      # show plan without API calls
-  python agents/scripts/batch_ingest_borderplex.py --delay 10     # seconds between queries
+  python agents/scripts/batch_ingest.py                # run all queries
+  python agents/scripts/batch_ingest.py --dry-run      # show plan without API calls
+  python agents/scripts/batch_ingest.py --delay 10     # seconds between queries
 """
 
 from __future__ import annotations
@@ -76,14 +76,19 @@ def _load_api_keys() -> list[str]:
 
 
 def _build_region_config(query: dict) -> dict:
-    """Build a RegionConfig dict from a YAML query entry. No location restriction."""
+    """Build a RegionConfig dict from a YAML query entry.
+
+    Supports optional ``location`` field for geo-targeted queries
+    (e.g. ``location: "El Paso, TX"``).
+    """
+    location = query.get("location", "")
     return {
         "region_id": f"batch-{query['name']}",
         "display_name": query["name"],
-        "query_location": "",
-        "radius_miles": 9999,
-        "states": [],
-        "countries": ["US"],
+        "query_location": location,
+        "radius_miles": query.get("radius_miles", 9999),
+        "states": query.get("states", []),
+        "countries": query.get("countries", ["US"]),
         "sources": ["jsearch"],
         "role_categories": [],
         "keywords": query["keywords"],

--- a/agents/scripts/batch_ingest_borderplex.py
+++ b/agents/scripts/batch_ingest_borderplex.py
@@ -1,0 +1,238 @@
+"""
+Batch ingestion — budget-aware JSearch queries with API key rotation.
+
+Reads query configuration from agents/config/ingestion_queries.yaml.
+Rotates API keys when budget_per_key is reached or a 429 is received.
+Ingestion only — stages raw records for downstream processing.
+
+Prerequisites:
+  - JSEARCH_API_KEY (or JSEARCH_API_KEY_1, JSEARCH_API_KEY_2, ...) in .env
+  - PYTHON_DATABASE_URL for database staging
+
+Usage (from repo root):
+  python agents/scripts/batch_ingest_borderplex.py                # run all queries
+  python agents/scripts/batch_ingest_borderplex.py --dry-run      # show plan without API calls
+  python agents/scripts/batch_ingest_borderplex.py --delay 10     # seconds between queries
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+import uuid
+from pathlib import Path
+
+import yaml
+
+# Path bootstrap
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+os.environ.setdefault("PYTHONIOENCODING", "utf-8")
+
+from dotenv import load_dotenv  # noqa: E402
+
+load_dotenv(_REPO_ROOT / ".env")
+
+import structlog  # noqa: E402
+
+structlog.configure(
+    processors=[
+        structlog.processors.TimeStamper(fmt="iso"),
+        structlog.processors.add_log_level,
+        structlog.processors.JSONRenderer(),
+    ],
+    wrapper_class=structlog.BoundLogger,
+    context_class=dict,
+    logger_factory=structlog.PrintLoggerFactory(),
+)
+log = structlog.get_logger()
+
+_CONFIG_PATH = Path(__file__).parent.parent / "config" / "ingestion_queries.yaml"
+
+
+def _load_config() -> dict:
+    """Load query configuration from YAML."""
+    if not _CONFIG_PATH.exists():
+        log.error("config_not_found", path=str(_CONFIG_PATH))
+        sys.exit(1)
+    with open(_CONFIG_PATH) as f:
+        return yaml.safe_load(f)
+
+
+def _load_api_keys() -> list[str]:
+    """Load API keys from env vars: JSEARCH_API_KEY, JSEARCH_API_KEY_2."""
+    keys = []
+    primary = os.getenv("JSEARCH_API_KEY", "").strip()
+    if primary:
+        keys.append(primary)
+    secondary = os.getenv("JSEARCH_API_KEY_2", "").strip()
+    if secondary:
+        keys.append(secondary)
+    return keys
+
+
+def _build_region_config(query: dict) -> dict:
+    """Build a RegionConfig dict from a YAML query entry. No location restriction."""
+    return {
+        "region_id": f"batch-{query['name']}",
+        "display_name": query["name"],
+        "query_location": "",
+        "radius_miles": 9999,
+        "states": [],
+        "countries": ["US"],
+        "sources": ["jsearch"],
+        "role_categories": [],
+        "keywords": query["keywords"],
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Budget-aware batch ingestion via JSearch")
+    parser.add_argument("--dry-run", action="store_true", help="Show plan without API calls")
+    parser.add_argument("--delay", type=int, default=5, help="Seconds between queries (default: 5)")
+    args = parser.parse_args()
+
+    config = _load_config()
+    budget_per_key = config.get("budget_per_key", 500)
+    queries = config.get("queries", [])
+
+    if not queries:
+        log.error("no_queries_configured")
+        sys.exit(1)
+
+    api_keys = _load_api_keys()
+    if not api_keys and not args.dry_run:
+        log.error("no_api_keys_found", hint="Set JSEARCH_API_KEY or JSEARCH_API_KEY_1 in .env")
+        sys.exit(1)
+
+    total_requests = sum(q.get("pages", 10) for q in queries)
+
+    log.info(
+        "batch_plan",
+        queries=len(queries),
+        total_requests=total_requests,
+        api_keys_available=len(api_keys),
+        budget_per_key=budget_per_key,
+        total_budget=len(api_keys) * budget_per_key,
+        dry_run=args.dry_run,
+    )
+
+    if args.dry_run:
+        print(f"\n{'='*60}")
+        print(f"Batch Ingestion Plan")
+        print(f"{'='*60}")
+        for i, q in enumerate(queries, 1):
+            pages = q.get("pages", 10)
+            print(f"\n  [{i}] {q['name']}")
+            print(f"      Keywords: {q['keywords']}")
+            print(f"      Pages: {pages} ({pages} API requests, ~{pages * 10} results)")
+        print(f"\n  Total: {total_requests} API requests")
+        print(f"  Keys available: {len(api_keys)} x {budget_per_key} = {len(api_keys) * budget_per_key} budget")
+        print(f"  Delay: {args.delay}s between queries")
+        print(f"{'='*60}\n")
+        return
+
+    # Late imports
+    from agents.common.event_envelope import EventEnvelope
+    from agents.ingestion.agent import IngestionAgent
+
+    agent = IngestionAgent()
+    current_key_idx = 0
+    requests_used_on_key = 0
+    total_staged = 0
+    total_requests_used = 0
+
+    for i, query in enumerate(queries, 1):
+        pages = query.get("pages", 10)
+
+        # Check if current key has budget
+        if requests_used_on_key + pages > budget_per_key:
+            current_key_idx += 1
+            requests_used_on_key = 0
+            if current_key_idx >= len(api_keys):
+                log.warning("all_keys_exhausted", queries_remaining=len(queries) - i + 1)
+                break
+            log.info("key_rotation", new_key_idx=current_key_idx + 1)
+
+        # Set the active key
+        os.environ["JSEARCH_API_KEY"] = api_keys[current_key_idx]
+        os.environ["BATCH_SIZE"] = str(pages * 10)
+
+        region = _build_region_config(query)
+        correlation_id = f"batch-{query['name']}-{uuid.uuid4().hex[:8]}"
+
+        log.info(
+            "query_start",
+            num=f"{i}/{len(queries)}",
+            name=query["name"],
+            keywords=query["keywords"],
+            pages=pages,
+            key_idx=current_key_idx + 1,
+            key_budget_remaining=budget_per_key - requests_used_on_key,
+        )
+
+        event = EventEnvelope(
+            correlation_id=correlation_id,
+            agent_id="batch-ingest-script",
+            payload={"region_config": region, "source": "jsearch"},
+        )
+
+        try:
+            out = agent.process(event)
+            requests_used_on_key += pages
+            total_requests_used += pages
+
+            if out and out.payload.get("event_type") == "IngestBatch":
+                staged = out.payload.get("staged_count", 0)
+                dedup = out.payload.get("dedup_count", 0)
+                total_staged += staged
+                log.info(
+                    "query_complete",
+                    name=query["name"],
+                    staged=staged,
+                    dedup_skipped=dedup,
+                    running_total=total_staged,
+                    requests_used=total_requests_used,
+                )
+            elif out and out.payload.get("event_type") == "SourceFailure":
+                error = out.payload.get("error", "")
+                if "429" in str(error) or "rate" in str(error).lower():
+                    log.warning("rate_limited", name=query["name"], rotating_key=True)
+                    current_key_idx += 1
+                    requests_used_on_key = 0
+                    if current_key_idx >= len(api_keys):
+                        log.warning("all_keys_exhausted_429")
+                        break
+                else:
+                    log.warning("source_failure", name=query["name"], error=error)
+        except Exception as exc:
+            error_str = str(exc)
+            if "429" in error_str:
+                log.warning("rate_limited_exception", name=query["name"], rotating_key=True)
+                current_key_idx += 1
+                requests_used_on_key = 0
+                if current_key_idx >= len(api_keys):
+                    log.warning("all_keys_exhausted_429")
+                    break
+            else:
+                log.error("query_failed", name=query["name"], error=error_str)
+
+        if i < len(queries):
+            time.sleep(args.delay)
+
+    log.info(
+        "batch_complete",
+        total_staged=total_staged,
+        total_requests=total_requests_used,
+        keys_used=current_key_idx + 1,
+    )
+    print(f"\nDone. {total_staged} records staged. {total_requests_used} API requests used across {current_key_idx + 1} key(s).")
+    print("Run processing loop: python agents/scripts/run_processing_loop.py")
+
+
+if __name__ == "__main__":
+    main()

--- a/agents/scripts/batch_ingest_borderplex.py
+++ b/agents/scripts/batch_ingest_borderplex.py
@@ -123,7 +123,7 @@ def main() -> None:
 
     if args.dry_run:
         print(f"\n{'='*60}")
-        print(f"Batch Ingestion Plan")
+        print("Batch Ingestion Plan")
         print(f"{'='*60}")
         for i, q in enumerate(queries, 1):
             pages = q.get("pages", 10)

--- a/agents/scripts/llm_audit_cost_report.py
+++ b/agents/scripts/llm_audit_cost_report.py
@@ -1,0 +1,188 @@
+# ruff: noqa: T201
+"""Summarize LLM spend from dbo.llm_audit_log and project cost for N jobs.
+
+Usage (repo root, venv activated):
+
+    python agents/scripts/llm_audit_cost_report.py
+    python agents/scripts/llm_audit_cost_report.py --project-jobs 1000
+
+Reads PYTHON_DATABASE_URL from .env.
+
+Notes:
+- ``extracted_intelligence.extraction_cost_usd`` is the per-job rollup from Skills Extraction
+  (tasks + responsibilities + skills + pass-1 metadata). Use AVG for projection.
+- ``llm_audit_log`` rows include taxonomy batch calls and enrichment (dedup embeddings, spam
+  preview) which are not strictly one row per job; enrichment projection uses total
+  enrichment-related cost divided by current ``job_postings`` count as a rough per-job add-on.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from sqlalchemy import text  # noqa: E402
+
+from agents.common.data_store.database import get_engine  # noqa: E402
+from agents.common.env import load_repo_root_dotenv  # noqa: E402
+
+load_repo_root_dotenv()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="LLM audit cost summary and projection")
+    parser.add_argument(
+        "--project-jobs",
+        type=int,
+        default=1000,
+        help="Raw normalized job count to project (default: 1000)",
+    )
+    args = parser.parse_args()
+
+    engine = get_engine()
+    with engine.connect() as conn:
+        print("=== dbo.llm_audit_log — by agent_name ===\n")
+        rows = conn.execute(
+            text(
+                """
+                SELECT agent_name,
+                       COUNT(*) AS calls,
+                       COALESCE(SUM(cost_usd), 0) AS sum_cost_usd,
+                       COALESCE(SUM(COALESCE(input_tokens, 0) + COALESCE(output_tokens, 0)), 0) AS sum_tokens
+                FROM dbo.llm_audit_log
+                GROUP BY agent_name
+                ORDER BY sum_cost_usd DESC NULLS LAST, calls DESC
+                """
+            )
+        ).fetchall()
+        if not rows:
+            print("(no rows in llm_audit_log)")
+        else:
+            print(f"{'agent_name':<40} {'calls':>8} {'sum_cost_usd':>14} {'sum_tokens':>12}")
+            print("-" * 78)
+            total_calls = 0
+            total_cost = 0.0
+            total_tok = 0
+            for r in rows:
+                print(f"{r[0]:<40} {r[1]:>8} {float(r[2]):>14.6f} {r[3]:>12}")
+                total_calls += r[1]
+                total_cost += float(r[2] or 0)
+                total_tok += r[3] or 0
+            print("-" * 78)
+            print(f"{'TOTAL':<40} {total_calls:>8} {total_cost:>14.6f} {total_tok:>12}")
+
+        print("\n=== dbo.extracted_intelligence — extraction_cost_usd ===\n")
+        row = conn.execute(
+            text(
+                """
+                SELECT COUNT(*) AS n,
+                       COALESCE(SUM(extraction_cost_usd), 0) AS sum_cost,
+                       COALESCE(AVG(NULLIF(extraction_cost_usd, 0)), 0) AS avg_cost_nonzero
+                FROM dbo.extracted_intelligence
+                """
+            )
+        ).one()
+        n_ext, sum_ext, avg_nz = int(row[0]), float(row[1]), float(row[2])
+        print(f"Rows: {n_ext}")
+        print(f"Sum extraction_cost_usd: {sum_ext:.6f}")
+        print(f"Avg extraction_cost_usd (excluding zeros): {avg_nz:.6f}")
+
+        print("\n=== Normalized jobs — description fill rate (for projection) ===\n")
+        row2 = conn.execute(
+            text(
+                """
+                SELECT COUNT(*) AS total,
+                       SUM(CASE WHEN description IS NULL OR TRIM(description) = '' THEN 1 ELSE 0 END) AS empty_desc
+                FROM dbo.normalized_jobs
+                """
+            )
+        ).one()
+        total_nj, empty_nj = int(row2[0]), int(row2[1] or 0)
+        if total_nj == 0:
+            fill_rate = 0.54
+            print("No normalized_jobs rows; using default 54% with-description rate for projection.")
+        else:
+            fill_rate = (total_nj - empty_nj) / total_nj
+            print(f"normalized_jobs: {total_nj} total, {empty_nj} empty description")
+            print(f"Fraction with description (eligible for Pass-2 LLM): {fill_rate:.1%}")
+
+        print("\n=== Enrichment LLM (audit) vs job_postings ===\n")
+        row3 = conn.execute(
+            text(
+                """
+                SELECT COALESCE(SUM(l.cost_usd), 0)
+                FROM dbo.llm_audit_log l
+                WHERE l.agent_name LIKE 'enrichment%'
+                """
+            )
+        ).scalar()
+        enrich_cost = float(row3 or 0)
+        jp = conn.execute(text("SELECT COUNT(*) FROM dbo.job_postings")).scalar()
+        jp_n = int(jp or 0)
+        enrich_per_job = enrich_cost / jp_n if jp_n else 0.0
+        print(f"Sum cost_usd (agent_name LIKE 'enrichment%%'): {enrich_cost:.6f}")
+        print(f"job_postings count: {jp_n}")
+        print(f"Implied enrichment LLM cost per posting (rough): {enrich_per_job:.6f}")
+
+        row_audit_skills = conn.execute(
+            text(
+                """
+                SELECT COALESCE(SUM(cost_usd), 0)
+                FROM dbo.llm_audit_log
+                WHERE agent_name IN (
+                    'skills-extraction-tasks',
+                    'skills-extraction-responsibilities',
+                    'skills-extraction-agent',
+                    'taxonomy-resolver'
+                )
+                """
+            )
+        ).scalar()
+        audit_skills_total = float(row_audit_skills or 0)
+
+        print(f"\n=== Projection — {args.project_jobs} raw jobs through normalize → extract → enrich ===\n")
+        jobs_with_text = int(round(args.project_jobs * fill_rate))
+        avg_ex = avg_nz if avg_nz > 0 else (sum_ext / n_ext if n_ext else 0.0)
+        proj_extract = jobs_with_text * avg_ex
+        proj_enrich = args.project_jobs * enrich_per_job if enrich_per_job > 0 else 0.0
+        if jp_n == 0:
+            proj_enrich = 0.0
+            print("(job_postings is empty — enrichment per-job estimate skipped.)")
+        print(f"Assumed jobs needing Pass-2 extraction: ~{jobs_with_text} ({fill_rate:.0%} of {args.project_jobs})")
+        print(f"Avg extraction_cost_usd per extracted row (DB column): {avg_ex:.6f}")
+        print(f"Projected skills extraction (from extraction_cost_usd only): ~${proj_extract:.2f}")
+
+        proj_audit = 0.0
+        if n_ext > 0 and audit_skills_total > 0:
+            audit_per_extracted = audit_skills_total / n_ext
+            proj_audit = jobs_with_text * audit_per_extracted
+            print(
+                f"Historical audit cost (tasks+resp+skills+taxonomy) / extracted rows: "
+                f"${audit_skills_total:.4f} / {n_ext} = ${audit_per_extracted:.4f} per row"
+            )
+            print(
+                f"Projected skills path (audit-based, same mix): ~${proj_audit:.2f} "
+                f"(often closer to actual LLM spend than extraction_cost_usd alone)"
+            )
+
+        print(f"Projected enrichment LLM (linear on job count): ~${proj_enrich:.2f}")
+        print(
+            f"Projected subtotal (extraction_cost_usd method + enrichment): "
+            f"~${proj_extract + proj_enrich:.2f}"
+        )
+        if proj_audit > 0:
+            print(
+                f"Projected subtotal (audit-based skills + enrichment): "
+                f"~${proj_audit + proj_enrich:.2f}"
+            )
+        print(
+            "\nNote: extraction_cost_usd may not include every billed token path; "
+            "prefer the audit-based line when it differs materially."
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/agents/scripts/run_processing_loop.py
+++ b/agents/scripts/run_processing_loop.py
@@ -1,0 +1,231 @@
+"""
+Processing loop — paced Normalize → Extract → Enrich pipeline.
+
+Picks up pending raw records in FIFO order, processes them through
+normalization, skills extraction, and enrichment. Pauses between batches
+to respect LLM rate limits. Exits when no pending records remain.
+
+This is Loop 2 of the flywheel pattern (see issue #161):
+  Loop 1: batch_ingest_borderplex.py fills raw_ingested_jobs
+  Loop 2: this script processes them at a sustainable pace
+
+Prerequisites:
+  - PYTHON_DATABASE_URL set
+  - Azure OpenAI keys set (for extraction + enrichment LLM calls)
+  - Optional: NORM_BATCH_SIZE env var (default: 50)
+
+Usage (from repo root):
+  python agents/scripts/run_processing_loop.py
+  python agents/scripts/run_processing_loop.py --batch-size 25 --delay 15
+  python agents/scripts/run_processing_loop.py --max-iterations 5
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+
+# Path bootstrap
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+os.environ.setdefault("PYTHONIOENCODING", "utf-8")
+
+from dotenv import load_dotenv  # noqa: E402
+
+load_dotenv(_REPO_ROOT / ".env")
+
+import structlog  # noqa: E402
+
+structlog.configure(
+    processors=[
+        structlog.processors.TimeStamper(fmt="iso"),
+        structlog.processors.add_log_level,
+        structlog.processors.JSONRenderer(),
+    ],
+    wrapper_class=structlog.BoundLogger,
+    context_class=dict,
+    logger_factory=structlog.PrintLoggerFactory(),
+)
+log = structlog.get_logger()
+
+
+def _count_pending() -> int:
+    """Count raw_ingested_jobs with processing_status='pending'."""
+    try:
+        from agents.common.data_store.database import session_scope
+        from agents.common.data_store.models import RawIngestedJob
+
+        with session_scope() as session:
+            return session.query(RawIngestedJob).filter(
+                RawIngestedJob.processing_status == "pending"
+            ).count()
+    except Exception as exc:
+        log.error("count_pending_failed", error=str(exc))
+        return -1
+
+
+def _count_enriched() -> int:
+    """Count job_postings (enriched output)."""
+    try:
+        from agents.common.data_store.database import session_scope
+        from agents.common.data_store.models import JobPosting
+
+        with session_scope() as session:
+            return session.query(JobPosting).count()
+    except Exception as exc:
+        log.error("count_enriched_failed", error=str(exc))
+        return -1
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Paced processing loop (Norm → Extract → Enrich)")
+    parser.add_argument("--batch-size", type=int, default=50, help="Records per iteration (default: 50)")
+    parser.add_argument("--delay", type=int, default=10, help="Seconds between iterations (default: 10)")
+    parser.add_argument("--max-iterations", type=int, default=0, help="Max iterations (0 = run until empty)")
+    parser.add_argument("--dry-run", action="store_true", help="Show pending count without processing")
+    args = parser.parse_args()
+
+    # Set batch size for normalization agent
+    os.environ["NORM_BATCH_SIZE"] = str(args.batch_size)
+
+    pending = _count_pending()
+    enriched = _count_enriched()
+
+    log.info(
+        "processing_loop_start",
+        pending=pending,
+        enriched=enriched,
+        batch_size=args.batch_size,
+        delay=args.delay,
+        max_iterations=args.max_iterations or "unlimited",
+    )
+
+    if args.dry_run:
+        print(f"\nPending: {pending} raw records")
+        print(f"Enriched: {enriched} job postings")
+        print(f"Batch size: {args.batch_size}")
+        estimated_iterations = (pending + args.batch_size - 1) // args.batch_size if pending > 0 else 0
+        print(f"Estimated iterations: {estimated_iterations}")
+        print(f"Estimated time: ~{estimated_iterations * (args.delay + 30)}s ({estimated_iterations * (args.delay + 30) // 60} min)")
+        return
+
+    if pending <= 0:
+        log.info("no_pending_records")
+        print("No pending records to process.")
+        return
+
+    # Late imports — heavy pipeline dependencies
+    from agents.common.event_envelope import EventEnvelope
+    from agents.enrichment.agent import EnrichmentAgent
+    from agents.normalization.agent import NormalizationAgent
+    from agents.skills_extraction.agent import SkillsExtractionAgent
+
+    norm_agent = NormalizationAgent()
+    extract_agent = SkillsExtractionAgent()
+    enrich_agent = EnrichmentAgent()
+
+    iteration = 0
+    total_processed = 0
+    total_errors = 0
+
+    while True:
+        iteration += 1
+        if args.max_iterations and iteration > args.max_iterations:
+            log.info("max_iterations_reached", max=args.max_iterations)
+            break
+
+        pending = _count_pending()
+        if pending <= 0:
+            log.info("all_records_processed", total_processed=total_processed, total_errors=total_errors)
+            break
+
+        log.info(
+            "iteration_start",
+            iteration=iteration,
+            pending=pending,
+            batch_size=min(args.batch_size, pending),
+        )
+
+        # Build a trigger event (normalization reads from DB, not from payload)
+        trigger = EventEnvelope(
+            correlation_id=f"processing-loop-iter-{iteration}",
+            agent_id="processing-loop",
+            payload={"event_type": "ProcessingTrigger", "batch_id": f"loop-{iteration}"},
+        )
+
+        try:
+            # Stage 1: Normalize
+            norm_out = norm_agent.process(trigger)
+            if norm_out is None:
+                log.error("normalization_returned_none", iteration=iteration)
+                total_errors += 1
+                time.sleep(args.delay)
+                continue
+
+            norm_count = norm_out.payload.get("normalized_count", 0)
+            quarantined = norm_out.payload.get("quarantined_count", 0)
+            log.info("normalized", count=norm_count, quarantined=quarantined, iteration=iteration)
+
+            if norm_count == 0:
+                log.info("nothing_normalized", iteration=iteration)
+                time.sleep(args.delay)
+                continue
+
+            # Stage 2: Extract skills
+            extract_out = extract_agent.process(norm_out)
+            if extract_out is None:
+                log.error("extraction_returned_none", iteration=iteration)
+                total_errors += 1
+                time.sleep(args.delay)
+                continue
+
+            extract_count = extract_out.payload.get("records_extracted", 0)
+            log.info("extracted", count=extract_count, iteration=iteration)
+
+            # Stage 3: Enrich
+            enrich_out = enrich_agent.process(extract_out)
+            if enrich_out is None:
+                log.error("enrichment_returned_none", iteration=iteration)
+                total_errors += 1
+                time.sleep(args.delay)
+                continue
+
+            enriched_count = enrich_out.payload.get("enriched_count", 0)
+            log.info("enriched", count=enriched_count, iteration=iteration)
+
+            total_processed += norm_count
+            enriched_total = _count_enriched()
+            remaining = _count_pending()
+
+            log.info(
+                "iteration_complete",
+                iteration=iteration,
+                batch_processed=norm_count,
+                total_processed=total_processed,
+                total_enriched=enriched_total,
+                remaining=remaining,
+            )
+
+        except Exception as exc:
+            log.error("iteration_failed", iteration=iteration, error=str(exc))
+            total_errors += 1
+
+        if _count_pending() > 0:
+            log.info("rate_limit_pause", seconds=args.delay)
+            time.sleep(args.delay)
+
+    enriched_final = _count_enriched()
+    print(f"\nProcessing complete.")
+    print(f"  Iterations: {iteration}")
+    print(f"  Records processed: {total_processed}")
+    print(f"  Errors: {total_errors}")
+    print(f"  Total enriched job postings: {enriched_final}")
+
+
+if __name__ == "__main__":
+    main()

--- a/agents/scripts/run_processing_loop.py
+++ b/agents/scripts/run_processing_loop.py
@@ -220,7 +220,7 @@ def main() -> None:
             time.sleep(args.delay)
 
     enriched_final = _count_enriched()
-    print(f"\nProcessing complete.")
+    print("\nProcessing complete.")
     print(f"  Iterations: {iteration}")
     print(f"  Records processed: {total_processed}")
     print(f"  Errors: {total_errors}")

--- a/agents/scripts/run_processing_loop.py
+++ b/agents/scripts/run_processing_loop.py
@@ -6,7 +6,7 @@ normalization, skills extraction, and enrichment. Pauses between batches
 to respect LLM rate limits. Exits when no pending records remain.
 
 This is Loop 2 of the flywheel pattern (see issue #161):
-  Loop 1: batch_ingest_borderplex.py fills raw_ingested_jobs
+  Loop 1: batch_ingest.py fills raw_ingested_jobs
   Loop 2: this script processes them at a sustainable pace
 
 Prerequisites:

--- a/agents/scripts/run_processing_loop.py
+++ b/agents/scripts/run_processing_loop.py
@@ -69,14 +69,36 @@ def _count_pending() -> int:
         return -1
 
 
+def _count_unextracted() -> int:
+    """Count normalized_jobs that don't have an extracted_intelligence row yet."""
+    try:
+        from agents.common.data_store.database import session_scope
+        from agents.common.data_store.models import ExtractedIntelligence, NormalizedJob
+
+        with session_scope() as session:
+            return (
+                session.query(NormalizedJob)
+                .outerjoin(
+                    ExtractedIntelligence,
+                    NormalizedJob.id == ExtractedIntelligence.normalized_job_id,
+                )
+                .filter(ExtractedIntelligence.id == None)  # noqa: E711
+                .count()
+            )
+    except Exception as exc:
+        log.error("count_unextracted_failed", error=str(exc))
+        return -1
+
+
 def _count_enriched() -> int:
     """Count job_postings (enriched output)."""
     try:
         from agents.common.data_store.database import session_scope
-        from agents.common.data_store.models import JobPosting
 
         with session_scope() as session:
-            return session.query(JobPosting).count()
+            from sqlalchemy import text
+            row = session.execute(text("SELECT COUNT(*) FROM dbo.job_postings")).scalar()
+            return row or 0
     except Exception as exc:
         log.error("count_enriched_failed", error=str(exc))
         return -1
@@ -105,18 +127,24 @@ def main() -> None:
         max_iterations=args.max_iterations or "unlimited",
     )
 
+    unextracted_preview = _count_unextracted()
+
     if args.dry_run:
-        print(f"\nPending: {pending} raw records")
+        print(f"\nPending raw: {pending}")
+        print(f"Unextracted normalized: {unextracted_preview}")
         print(f"Enriched: {enriched} job postings")
         print(f"Batch size: {args.batch_size}")
-        estimated_iterations = (pending + args.batch_size - 1) // args.batch_size if pending > 0 else 0
+        total_work = max(pending, unextracted_preview)
+        estimated_iterations = (total_work + args.batch_size - 1) // args.batch_size if total_work > 0 else 0
         print(f"Estimated iterations: {estimated_iterations}")
         print(f"Estimated time: ~{estimated_iterations * (args.delay + 30)}s ({estimated_iterations * (args.delay + 30) // 60} min)")
         return
 
-    if pending <= 0:
-        log.info("no_pending_records")
-        print("No pending records to process.")
+    unextracted = _count_unextracted()
+
+    if pending <= 0 and unextracted <= 0:
+        log.info("nothing_to_process", pending=pending, unextracted=unextracted)
+        print("No pending or unextracted records to process.")
         return
 
     # Late imports — heavy pipeline dependencies
@@ -130,7 +158,9 @@ def main() -> None:
     enrich_agent = EnrichmentAgent()
 
     iteration = 0
-    total_processed = 0
+    total_normalized = 0
+    total_extracted = 0
+    total_enriched_count = 0
     total_errors = 0
 
     while True:
@@ -140,89 +170,92 @@ def main() -> None:
             break
 
         pending = _count_pending()
-        if pending <= 0:
-            log.info("all_records_processed", total_processed=total_processed, total_errors=total_errors)
+        unextracted = _count_unextracted()
+
+        if pending <= 0 and unextracted <= 0:
+            log.info(
+                "all_records_processed",
+                total_normalized=total_normalized,
+                total_extracted=total_extracted,
+                total_enriched=total_enriched_count,
+                total_errors=total_errors,
+            )
             break
 
         log.info(
             "iteration_start",
             iteration=iteration,
-            pending=pending,
-            batch_size=min(args.batch_size, pending),
+            pending_raw=pending,
+            unextracted=unextracted,
         )
 
-        # Build a trigger event (normalization reads from DB, not from payload)
         trigger = EventEnvelope(
             correlation_id=f"processing-loop-iter-{iteration}",
             agent_id="processing-loop",
-            payload={"event_type": "ProcessingTrigger", "batch_id": f"loop-{iteration}"},
+            payload={"event_type": "ProcessingTrigger", "batch_id": ""},
         )
 
         try:
-            # Stage 1: Normalize
+            # Stage 1: Normalize (may return 0 if all raw are already normalized)
             norm_out = norm_agent.process(trigger)
-            if norm_out is None:
-                log.error("normalization_returned_none", iteration=iteration)
-                total_errors += 1
-                time.sleep(args.delay)
-                continue
+            norm_count = 0
+            if norm_out is not None:
+                norm_count = norm_out.payload.get("normalized_count", 0)
+                quarantined = norm_out.payload.get("quarantined_count", 0)
+                if norm_count > 0 or quarantined > 0:
+                    log.info("normalized", count=norm_count, quarantined=quarantined, iteration=iteration)
+                total_normalized += norm_count
 
-            norm_count = norm_out.payload.get("normalized_count", 0)
-            quarantined = norm_out.payload.get("quarantined_count", 0)
-            log.info("normalized", count=norm_count, quarantined=quarantined, iteration=iteration)
+            # Stage 2: Extract skills (FIFO — finds unextracted records itself)
+            extract_event = norm_out or trigger
+            extract_out = extract_agent.process(extract_event)
+            extract_count = 0
+            if extract_out is not None:
+                records = extract_out.payload.get("records", [])
+                extract_count = len(records) if isinstance(records, list) else 0
+                log.info("extracted", count=extract_count, iteration=iteration)
+                total_extracted += extract_count
 
-            if norm_count == 0:
-                log.info("nothing_normalized", iteration=iteration)
-                time.sleep(args.delay)
-                continue
+            # Stage 3: Enrich (processes extraction output records)
+            if extract_out is not None and extract_count > 0:
+                enrich_out = enrich_agent.process(extract_out)
+                enriched_count = 0
+                if enrich_out is not None:
+                    enriched_count = enrich_out.payload.get("enriched_count", 0)
+                    log.info("enriched", count=enriched_count, iteration=iteration)
+                    total_enriched_count += enriched_count
 
-            # Stage 2: Extract skills
-            extract_out = extract_agent.process(norm_out)
-            if extract_out is None:
-                log.error("extraction_returned_none", iteration=iteration)
-                total_errors += 1
-                time.sleep(args.delay)
-                continue
-
-            extract_count = extract_out.payload.get("records_extracted", 0)
-            log.info("extracted", count=extract_count, iteration=iteration)
-
-            # Stage 3: Enrich
-            enrich_out = enrich_agent.process(extract_out)
-            if enrich_out is None:
-                log.error("enrichment_returned_none", iteration=iteration)
-                total_errors += 1
-                time.sleep(args.delay)
-                continue
-
-            enriched_count = enrich_out.payload.get("enriched_count", 0)
-            log.info("enriched", count=enriched_count, iteration=iteration)
-
-            total_processed += norm_count
             enriched_total = _count_enriched()
-            remaining = _count_pending()
+            remaining_raw = _count_pending()
+            remaining_unextracted = _count_unextracted()
 
             log.info(
                 "iteration_complete",
                 iteration=iteration,
-                batch_processed=norm_count,
-                total_processed=total_processed,
+                norm_batch=norm_count,
+                extract_batch=extract_count,
                 total_enriched=enriched_total,
-                remaining=remaining,
+                remaining_raw=remaining_raw,
+                remaining_unextracted=remaining_unextracted,
             )
+
+            if extract_count == 0 and norm_count == 0:
+                log.info("no_progress", iteration=iteration)
+                break
 
         except Exception as exc:
             log.error("iteration_failed", iteration=iteration, error=str(exc))
             total_errors += 1
 
-        if _count_pending() > 0:
-            log.info("rate_limit_pause", seconds=args.delay)
-            time.sleep(args.delay)
+        log.info("rate_limit_pause", seconds=args.delay)
+        time.sleep(args.delay)
 
     enriched_final = _count_enriched()
     print("\nProcessing complete.")
     print(f"  Iterations: {iteration}")
-    print(f"  Records processed: {total_processed}")
+    print(f"  Normalized: {total_normalized}")
+    print(f"  Extracted: {total_extracted}")
+    print(f"  Enriched: {total_enriched_count}")
     print(f"  Errors: {total_errors}")
     print(f"  Total enriched job postings: {enriched_final}")
 

--- a/agents/skills_extraction/agent.py
+++ b/agents/skills_extraction/agent.py
@@ -158,6 +158,11 @@ class EventOrDatabaseWorkItemLoader:
         if batch_id and check_db_connection():
             return self._from_database(batch_id)
 
+        # FIFO: load normalized records not yet extracted (processing loop mode)
+        if check_db_connection():
+            batch_size = int(os.environ.get("NORM_BATCH_SIZE", "50"))
+            return self._from_database_unextracted(batch_size)
+
         return []
 
     def _from_database(self, batch_id: str) -> list[ExtractionWorkItem]:
@@ -170,6 +175,22 @@ class EventOrDatabaseWorkItemLoader:
                 .all()
             )
 
+        return [self._from_normalized_row(row) for row in rows]
+
+    def _from_database_unextracted(self, limit: int = 50) -> list[ExtractionWorkItem]:
+        """FIFO: load normalized jobs that don't yet have extraction results."""
+        with session_scope() as session:
+            rows = (
+                session.query(NormalizedJob)
+                .outerjoin(
+                    ExtractedIntelligence,
+                    NormalizedJob.id == ExtractedIntelligence.normalized_job_id,
+                )
+                .filter(ExtractedIntelligence.id == None)  # noqa: E711
+                .order_by(NormalizedJob.id.asc())
+                .limit(limit)
+                .all()
+            )
         return [self._from_normalized_row(row) for row in rows]
 
     def _from_normalized_row(self, row: NormalizedJob) -> ExtractionWorkItem:

--- a/docs/planning/ARCHITECTURE_DEEP.md
+++ b/docs/planning/ARCHITECTURE_DEEP.md
@@ -379,6 +379,26 @@ class JobRecord(BaseModel):
 | Duplicate rate forwarded | < 0.5% |
 | Dead-letter volume | < 1%; alert above 2% |
 
+#### Flywheel Operational Pattern (Week 6+)
+
+The monolithic `pipeline_runner.py` chains all agents in a single pass, which couples ingestion throughput (API budget/rate-limited) to processing throughput (LLM rate-limited). The **flywheel pattern** decouples these into two independent loops connected via the database as a queue:
+
+**Loop 1 — Batch Ingest** (`agents/scripts/batch_ingest_borderplex.py`):
+- Reads query configuration from `agents/config/ingestion_queries.yaml`
+- Rotates API keys (`JSEARCH_API_KEY`, `JSEARCH_API_KEY_2`) when budget is exhausted or 429 received
+- Stages raw records to `raw_ingested_jobs` with `processing_status = 'pending'`
+- Does NOT trigger downstream processing — ingestion only
+- Supports `--dry-run` (show plan without API calls) and `--delay` (seconds between queries)
+
+**Loop 2 — Paced Processing** (`agents/scripts/run_processing_loop.py`):
+- Polls `raw_ingested_jobs` (pending) and `normalized_jobs` (unextracted) in a loop
+- Each iteration: Normalize → Skills Extraction → Enrichment
+- Pauses between iterations (`--delay`) to manage LLM rate limits
+- Exits when no pending/unextracted records remain, or `--max-iterations` reached
+- Supports `--batch-size`, `--delay`, `--max-iterations`, `--dry-run`
+
+This separation allows bulk ingestion (hundreds of API calls) to run independently from LLM-intensive processing, which can be throttled to match Azure OpenAI TPM/RPM limits.
+
 ---
 
 ### 2. Normalization Agent
@@ -1013,6 +1033,13 @@ SPAM_FLAG_THRESHOLD=0.7
 SPAM_REJECT_THRESHOLD=0.9
 SKILL_CONFIDENCE_THRESHOLD=0.75
 BATCH_SIZE=100
+
+# Flywheel / processing loop (Week 6+)
+JSEARCH_API_KEY_2=                             # Secondary JSearch key for rotation (optional)
+NORM_BATCH_SIZE=50                             # Records per normalization batch
+SKILLS_EXTRACTION_CHUNK_SIZE=50                # Records per extraction chunk before cooldown
+SKILLS_EXTRACTION_CHUNK_COOLDOWN=2             # Seconds between chunks (adjust to Azure TPM)
+SKILLS_EXTRACTION_DELAY=0.1                    # Seconds between records within a chunk
 
 # Model tier routing (Work Intelligence Agent)
 EXTRACTION_MODEL_SKILLS=claude-sonnet-4-5      # Sonnet-class for skills/responsibilities

--- a/docs/planning/ARCHITECTURE_DEEP.md
+++ b/docs/planning/ARCHITECTURE_DEEP.md
@@ -383,7 +383,7 @@ class JobRecord(BaseModel):
 
 The monolithic `pipeline_runner.py` chains all agents in a single pass, which couples ingestion throughput (API budget/rate-limited) to processing throughput (LLM rate-limited). The **flywheel pattern** decouples these into two independent loops connected via the database as a queue:
 
-**Loop 1 — Batch Ingest** (`agents/scripts/batch_ingest_borderplex.py`):
+**Loop 1 — Batch Ingest** (`agents/scripts/batch_ingest.py`):
 - Reads query configuration from `agents/config/ingestion_queries.yaml`
 - Rotates API keys (`JSEARCH_API_KEY`, `JSEARCH_API_KEY_2`) when budget is exhausted or 429 received
 - Stages raw records to `raw_ingested_jobs` with `processing_status = 'pending'`

--- a/scripts/pg-seed-data/README.md
+++ b/scripts/pg-seed-data/README.md
@@ -18,11 +18,15 @@ agents\.venv\Scripts\Activate.ps1          # Windows PowerShell
 # 3. Install dependencies (if not done yet)
 pip install -r agents/requirements.txt
 
-# 4. Seed the database
+# 4. Seed reference data (tables, taxonomies, companies, etc.)
 python scripts/pg-seed-data/seed_pg_database.py
 
-# 5. Verify — run the pipeline
-python agents/pipeline_runner.py
+# 5. Seed agent pipeline data (enriched job postings for analytics)
+python scripts/pg-seed-data/seed_agent_data.py
+
+# 6. Verify — run the flywheel pipeline
+python agents/scripts/batch_ingest.py --dry-run
+python agents/scripts/run_processing_loop.py --dry-run
 ```
 
 The seed script is **idempotent** — you can run it multiple times safely.
@@ -79,8 +83,11 @@ The seed script (`seed_pg_database.py`) does everything in one command:
 ```
 scripts/pg-seed-data/
   README.md                     ← This file
-  seed_pg_database.py           ← Seed script (junior devs run this)
-  export_pg_fixtures.py         ← Export script (admin only)
+  seed_pg_database.py           ← Seed reference data (junior devs run this)
+  seed_agent_data.py            ← Seed agent pipeline data (junior devs run this)
+  export_pg_fixtures.py         ← Export reference data (admin only)
+  export_agent_data.py          ← Export agent pipeline data (admin only)
+  clean_stale_postings.py       ← Purge old pipeline data (admin only)
   clean_schema.py               ← Schema cleaner (admin only)
   schema.sql                    ← Cleaned DDL (idempotent)
   schema_raw.sql                ← Raw pg_dump output (admin reference)
@@ -90,6 +97,11 @@ scripts/pg-seed-data/
     companies.json              ← 122 companies
     job_postings.json           ← 172 job postings
     ... (40 fixture files)
+  agent-fixtures/
+    raw_ingested_jobs.json      ← Ingested job data
+    normalized_jobs.json        ← Normalized records
+    extracted_intelligence.json ← Extraction results
+    job_postings.json           ← Enriched job postings
 ```
 
 ## Troubleshooting

--- a/scripts/pg-seed-data/clean_stale_postings.py
+++ b/scripts/pg-seed-data/clean_stale_postings.py
@@ -1,0 +1,121 @@
+"""
+Purge old agent pipeline data from the database before re-seeding.
+
+Admin tool: cleans job pipeline tables while preserving reference data
+and LLM audit logs (cost tracking).
+
+Usage (from project root, with venv activated):
+    python scripts/pg-seed-data/clean_stale_postings.py          # interactive
+    python scripts/pg-seed-data/clean_stale_postings.py --yes    # non-interactive
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+# Load .env from repo root (two levels up from this script)
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+load_dotenv(_REPO_ROOT / ".env")
+
+import psycopg2  # noqa: E402
+
+# Tables to clean, in reverse FK dependency order.
+# llm_audit_log is intentionally EXCLUDED — it persists for cost tracking.
+TABLES_TO_CLEAN = [
+    "extracted_intelligence",
+    "normalization_quarantine",
+    "normalized_jobs",
+    "job_ingestion_runs",
+    "raw_ingested_jobs",
+]
+
+
+def get_pg_connection() -> psycopg2.extensions.connection:
+    """Create psycopg2 connection from PYTHON_DATABASE_URL."""
+    dsn = os.getenv("PYTHON_DATABASE_URL", "")
+    dsn = dsn.replace("postgresql+psycopg2://", "postgresql://")
+    if not dsn:
+        print("ERROR: Set PYTHON_DATABASE_URL in your .env file")
+        sys.exit(1)
+    return psycopg2.connect(dsn)
+
+
+def get_row_count(cur: psycopg2.extensions.cursor, table: str) -> int:
+    """Get row count for a dbo table."""
+    cur.execute(f'SELECT COUNT(*) FROM "dbo"."{table}"')
+    return cur.fetchone()[0]
+
+
+def clean_tables(confirm: bool = False) -> None:
+    """Delete all rows from agent pipeline tables."""
+    print("=" * 60)
+    print("Clean Stale Pipeline Data")
+    print("=" * 60)
+
+    conn = get_pg_connection()
+    cur = conn.cursor()
+
+    # Show counts BEFORE
+    print("\nCurrent row counts:")
+    total_before = 0
+    for table in TABLES_TO_CLEAN:
+        try:
+            count = get_row_count(cur, table)
+            total_before += count
+            print(f"  {table}: {count:,}")
+        except psycopg2.errors.UndefinedTable:
+            conn.rollback()
+            print(f"  {table}: (table does not exist)")
+
+    if total_before == 0:
+        print("\nAll tables are already empty. Nothing to clean.")
+        cur.close()
+        conn.close()
+        return
+
+    print(f"\nTotal rows to delete: {total_before:,}")
+    print("(llm_audit_log is preserved for cost tracking)")
+
+    if not confirm:
+        response = input("\nProceed with deletion? [y/N]: ").strip().lower()
+        if response != "y":
+            print("Aborted.")
+            cur.close()
+            conn.close()
+            return
+
+    # Delete in reverse FK order
+    print("\nDeleting...")
+    for table in TABLES_TO_CLEAN:
+        try:
+            cur.execute(f'DELETE FROM "dbo"."{table}"')
+            deleted = cur.rowcount
+            print(f"  {table}: {deleted:,} rows deleted")
+        except psycopg2.errors.UndefinedTable:
+            conn.rollback()
+            print(f"  {table}: (table does not exist, skipped)")
+
+    conn.commit()
+
+    # Show counts AFTER
+    print("\nRow counts after cleanup:")
+    for table in TABLES_TO_CLEAN:
+        try:
+            count = get_row_count(cur, table)
+            print(f"  {table}: {count:,}")
+        except psycopg2.errors.UndefinedTable:
+            conn.rollback()
+            print(f"  {table}: (table does not exist)")
+
+    cur.close()
+    conn.close()
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    auto_confirm = "--yes" in sys.argv or "-y" in sys.argv
+    clean_tables(confirm=auto_confirm)

--- a/scripts/pg-seed-data/export_agent_data.py
+++ b/scripts/pg-seed-data/export_agent_data.py
@@ -1,0 +1,196 @@
+"""
+Export agent pipeline data to JSON fixtures for dev seeding.
+
+Admin tool: run after processing pipeline data, commit fixtures to git
+so devs can seed their local databases with enriched job postings.
+
+Usage (from project root, with venv activated):
+    python scripts/pg-seed-data/export_agent_data.py
+    python scripts/pg-seed-data/export_agent_data.py --limit 500  # cap per table
+
+Reads from PYTHON_DATABASE_URL and writes JSON files to scripts/pg-seed-data/agent-fixtures/.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import date, datetime
+from decimal import Decimal
+from pathlib import Path
+from uuid import UUID
+
+from dotenv import load_dotenv
+
+# Load .env from repo root (two levels up from this script)
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+load_dotenv(_REPO_ROOT / ".env")
+
+import psycopg2  # noqa: E402
+
+# ── Configuration ────────────────────────────────────────────────────
+
+# Agent pipeline tables to export, in dependency order
+AGENT_TABLES = [
+    "raw_ingested_jobs",
+    "job_ingestion_runs",
+    "normalized_jobs",
+    "normalization_quarantine",
+    "extracted_intelligence",
+    "llm_audit_log",
+    "employer_profiles",
+]
+
+OUTPUT_DIR = Path(__file__).parent / "agent-fixtures"
+
+
+# ── Helpers (reused from export_pg_fixtures.py) ──────────────────────
+
+
+def json_serializer(obj: object) -> str | float | None:
+    """Custom JSON serializer for PostgreSQL types."""
+    if isinstance(obj, datetime):
+        return obj.isoformat()
+    if isinstance(obj, date):
+        return obj.isoformat()
+    if isinstance(obj, Decimal):
+        return float(obj)
+    if isinstance(obj, UUID):
+        return str(obj).upper()
+    if isinstance(obj, (bytes, memoryview)):
+        raw = bytes(obj) if isinstance(obj, memoryview) else obj
+        return raw.decode("utf-8", errors="replace")
+    raise TypeError(f"Not JSON serializable: {type(obj)}")
+
+
+def get_pg_connection() -> psycopg2.extensions.connection:
+    """Create psycopg2 connection from PYTHON_DATABASE_URL."""
+    dsn = os.getenv("PYTHON_DATABASE_URL", "")
+    dsn = dsn.replace("postgresql+psycopg2://", "postgresql://")
+    if not dsn:
+        print("ERROR: Set PYTHON_DATABASE_URL in your .env file")
+        sys.exit(1)
+    return psycopg2.connect(dsn)
+
+
+def get_columns(
+    cur: psycopg2.extensions.cursor, table_name: str
+) -> list[tuple[str, str, str]]:
+    """Get (column_name, data_type, udt_name) for a dbo table."""
+    cur.execute(
+        """
+        SELECT column_name, data_type, udt_name
+        FROM information_schema.columns
+        WHERE table_schema = 'dbo' AND table_name = %s
+        ORDER BY ordinal_position
+    """,
+        (table_name,),
+    )
+    return cur.fetchall()
+
+
+def export_table(
+    cur: psycopg2.extensions.cursor,
+    table_name: str,
+    columns: list[tuple[str, str, str]],
+    limit: int | None = None,
+) -> list[dict]:
+    """Export one table to a list of dicts."""
+    select_parts: list[str] = []
+    for col_name, _data_type, udt_name in columns:
+        if udt_name == "vector":
+            select_parts.append(f'"{col_name}"::text AS "{col_name}"')
+        else:
+            select_parts.append(f'"{col_name}"')
+
+    select_clause = ", ".join(select_parts)
+    query = f'SELECT {select_clause} FROM "dbo"."{table_name}"'
+    if limit:
+        query += f" LIMIT {limit}"
+    cur.execute(query)
+    rows = cur.fetchall()
+
+    records: list[dict] = []
+    for row in rows:
+        record: dict = {}
+        for i, (col_name, _dt, _udt) in enumerate(columns):
+            record[col_name] = row[i]
+        records.append(record)
+
+    return records
+
+
+def write_json(filepath: Path, data: object) -> None:
+    """Write data to a JSON file with custom serialization."""
+    filepath.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(data, default=json_serializer, indent=2, ensure_ascii=False)
+    filepath.write_text(text + "\n", encoding="utf-8")
+
+
+# ── Main ─────────────────────────────────────────────────────────────
+
+
+def export_all(limit: int | None = None) -> None:
+    """Export all agent pipeline tables to JSON fixtures."""
+    print("=" * 60)
+    print("Agent Pipeline Data Export")
+    print("=" * 60)
+
+    conn = get_pg_connection()
+    cur = conn.cursor()
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    metadata: dict = {
+        "exportedAt": datetime.utcnow().isoformat() + "Z",
+        "source": "postgresql",
+        "schema": "dbo",
+        "counts": {},
+        "skipped": [],
+    }
+
+    exported_count = 0
+    total_rows = 0
+
+    for table in AGENT_TABLES:
+        columns = get_columns(cur, table)
+        if not columns:
+            metadata["skipped"].append(table)
+            print(f"  {table}: SKIPPED (table does not exist or no columns)")
+            continue
+
+        records = export_table(cur, table, columns, limit=limit)
+
+        if len(records) == 0:
+            metadata["skipped"].append(table)
+            print(f"  {table}: SKIPPED (0 rows)")
+            continue
+
+        out_path = OUTPUT_DIR / f"{table}.json"
+        write_json(out_path, records)
+
+        metadata["counts"][table] = len(records)
+        exported_count += 1
+        total_rows += len(records)
+        print(f"  {table}: {len(records):,} rows -> {out_path.name}")
+
+    # Write metadata
+    write_json(OUTPUT_DIR / "metadata.json", metadata)
+
+    cur.close()
+    conn.close()
+
+    print(f"\n{'=' * 60}")
+    print(f"Export complete: {total_rows:,} total rows across {exported_count} tables")
+    print(f"Skipped: {len(metadata['skipped'])} tables (empty or missing)")
+    print(f"Fixtures written to: {OUTPUT_DIR}")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    row_limit = None
+    for i, arg in enumerate(sys.argv):
+        if arg == "--limit" and i + 1 < len(sys.argv):
+            row_limit = int(sys.argv[i + 1])
+    export_all(limit=row_limit)

--- a/scripts/pg-seed-data/seed_agent_data.py
+++ b/scripts/pg-seed-data/seed_agent_data.py
@@ -1,0 +1,211 @@
+"""
+Seed a local PostgreSQL database with agent pipeline data from JSON fixtures.
+
+Junior-dev tool: run after seed_pg_database.py to populate enriched job postings
+so analytics and visualization dashboards have data to work with.
+
+Usage (from project root, with venv activated):
+    python scripts/pg-seed-data/seed_agent_data.py
+
+Reads:  scripts/pg-seed-data/agent-fixtures/*.json  (data)
+Writes: PostgreSQL database specified by PYTHON_DATABASE_URL
+
+Uses UPSERT (INSERT ... ON CONFLICT DO NOTHING) — safe to run multiple times.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+# Load .env from repo root (two levels up from this script)
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+load_dotenv(_REPO_ROOT / ".env")
+
+import psycopg2  # noqa: E402
+import psycopg2.extras  # noqa: E402
+
+# ── Paths ─────────────────────────────────────────────────────────────
+
+FIXTURES_DIR = Path(__file__).parent / "agent-fixtures"
+
+# ── FK-safe insert order ──────────────────────────────────────────────
+# Tables ordered so that FK dependencies are satisfied:
+# raw_ingested_jobs has no FK deps on other agent tables
+# job_ingestion_runs has no FK deps on other agent tables
+# normalized_jobs → raw_ingested_jobs (via raw_ingested_job_id)
+# extracted_intelligence → normalized_jobs (via normalized_job_id)
+# employer_profiles has no FK deps on other agent tables
+# llm_audit_log has no FK deps on other agent tables
+
+INSERT_ORDER = [
+    "raw_ingested_jobs",
+    "job_ingestion_runs",
+    "normalized_jobs",
+    "normalization_quarantine",
+    "extracted_intelligence",
+    "employer_profiles",
+    "llm_audit_log",
+]
+
+
+def get_pg_connection() -> psycopg2.extensions.connection:
+    """Create psycopg2 connection from PYTHON_DATABASE_URL."""
+    dsn = os.getenv("PYTHON_DATABASE_URL", "")
+    dsn = dsn.replace("postgresql+psycopg2://", "postgresql://")
+    if not dsn:
+        print("ERROR: Set PYTHON_DATABASE_URL in your .env file")
+        sys.exit(1)
+    return psycopg2.connect(dsn)
+
+
+def get_primary_key(cur: psycopg2.extensions.cursor, table: str) -> list[str]:
+    """Get primary key column(s) for a dbo table."""
+    cur.execute(
+        """
+        SELECT a.attname
+        FROM pg_index i
+        JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
+        JOIN pg_class c ON c.oid = i.indrelid
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE i.indisprimary
+          AND c.relname = %s
+          AND n.nspname = 'dbo'
+        ORDER BY array_position(i.indkey, a.attnum)
+    """,
+        (table,),
+    )
+    return [row[0] for row in cur.fetchall()]
+
+
+def upsert_records(
+    cur: psycopg2.extensions.cursor,
+    table: str,
+    records: list[dict],
+    pk_cols: list[str],
+) -> tuple[int, int]:
+    """Insert records with ON CONFLICT DO NOTHING. Returns (inserted, skipped)."""
+    if not records:
+        return 0, 0
+
+    columns = list(records[0].keys())
+    col_names = ", ".join(f'"{c}"' for c in columns)
+    placeholders = ", ".join(["%s"] * len(columns))
+    conflict_cols = ", ".join(f'"{c}"' for c in pk_cols)
+
+    sql = (
+        f'INSERT INTO "dbo"."{table}" ({col_names}) '
+        f"VALUES ({placeholders}) "
+        f"ON CONFLICT ({conflict_cols}) DO NOTHING"
+    )
+
+    inserted = 0
+    skipped = 0
+
+    for record in records:
+        values = []
+        for col in columns:
+            val = record.get(col)
+            # Convert ISO datetime strings back to datetime objects
+            if isinstance(val, str) and len(val) >= 19:
+                for fmt in ("%Y-%m-%dT%H:%M:%S.%f", "%Y-%m-%dT%H:%M:%S"):
+                    try:
+                        val = datetime.fromisoformat(val)
+                        break
+                    except ValueError:
+                        continue
+            # Handle JSON/dict values — store as JSON string
+            if isinstance(val, (dict, list)):
+                val = json.dumps(val)
+            values.append(val)
+
+        cur.execute(sql, values)
+        if cur.rowcount > 0:
+            inserted += 1
+        else:
+            skipped += 1
+
+    return inserted, skipped
+
+
+def run_migrations() -> None:
+    """Run agent migrations to ensure schema is current."""
+    try:
+        from agents.common.data_store.database import get_engine
+        from agents.common.data_store.migrations import run_migrations as _migrate
+
+        _migrate(get_engine())
+        print("Migrations: OK")
+    except Exception as e:
+        print(f"Migrations: SKIPPED ({e})")
+        print("  (Tables may already exist — continuing with seed)")
+
+
+def seed_all() -> None:
+    """Seed all agent pipeline tables from JSON fixtures."""
+    print("=" * 60)
+    print("Agent Pipeline Data Seed")
+    print("=" * 60)
+
+    if not FIXTURES_DIR.exists():
+        print(f"\nERROR: Fixtures directory not found: {FIXTURES_DIR}")
+        print("Run export_agent_data.py first to generate fixtures.")
+        sys.exit(1)
+
+    # Run migrations first
+    print("\nRunning migrations...")
+    run_migrations()
+
+    conn = get_pg_connection()
+    cur = conn.cursor()
+
+    total_inserted = 0
+    total_skipped = 0
+
+    print(f"\nSeeding from: {FIXTURES_DIR}\n")
+
+    for table in INSERT_ORDER:
+        fixture_file = FIXTURES_DIR / f"{table}.json"
+        if not fixture_file.exists():
+            print(f"  {table}: SKIPPED (no fixture file)")
+            continue
+
+        records = json.loads(fixture_file.read_text(encoding="utf-8"))
+        if not records:
+            print(f"  {table}: SKIPPED (0 records in fixture)")
+            continue
+
+        pk_cols = get_primary_key(cur, table)
+        if not pk_cols:
+            print(f"  {table}: SKIPPED (no primary key found — table may not exist)")
+            conn.rollback()
+            continue
+
+        try:
+            inserted, skipped = upsert_records(cur, table, records, pk_cols)
+            conn.commit()
+            total_inserted += inserted
+            total_skipped += skipped
+            print(
+                f"  {table}: {inserted:,} inserted, {skipped:,} skipped "
+                f"(of {len(records):,} total)"
+            )
+        except Exception as e:
+            conn.rollback()
+            print(f"  {table}: ERROR — {e}")
+
+    print(f"\n{'=' * 60}")
+    print(f"Seed complete: {total_inserted:,} inserted, {total_skipped:,} skipped")
+    print("=" * 60)
+
+    cur.close()
+    conn.close()
+
+
+if __name__ == "__main__":
+    seed_all()


### PR DESCRIPTION
## Summary
- Decouple ingestion from processing pipeline (flywheel pattern)
- Add budget-aware batch ingestion with API key rotation
- Add zip code resolution via postal_geo_data lookup during normalization
- Promote flywheel as primary pipeline in all documentation
- Add data seeding scripts (export, import, cleanup) for dev workflow
- Revert ingestion queries to broad agentic/LLM-consumer keywords

## New Files
- agents/scripts/batch_ingest.py
- agents/scripts/run_processing_loop.py
- agents/config/ingestion_queries.yaml (13 queries, 3 tiers)
- agents/docs/INGESTION_QUERY_RESULTS.md (Round 1-3, 1065 records)
- scripts/pg-seed-data/clean_stale_postings.py
- scripts/pg-seed-data/export_agent_data.py
- scripts/pg-seed-data/seed_agent_data.py

## Test plan
- [ ] dry-run on batch_ingest.py shows 13 queries
- [ ] dry-run on run_processing_loop.py shows pending count
- [ ] Migrations run without error
- [ ] seed_agent_data.py imports fixtures with UPSERT
- [ ] clean_stale_postings.py preserves llm_audit_log

Closes #161, Closes #160, Closes #162